### PR TITLE
Fix various typos

### DIFF
--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -561,7 +561,7 @@ private:
     static Application *_pcSingleton;
     /// argument helper function
     static void ParseOptions(int argc, char ** argv);
-    /// checks if the environment is allreight
+    /// checks if the environment is alright
     //static void CheckEnv(void);
     /// Search for the FreeCAD home path based on argv[0]
     /*!

--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -218,7 +218,7 @@ public:
         MapToNamed,
 
         /** Lookup the indexed name with the given mapped name. If the given
-         * name starts witht elementMapPrefix(), it will be stripped before used
+         * name starts with elementMapPrefix(), it will be stripped before used
          * for lookup, or else, the given name is directly used for lookup.
          */
         MapToIndexedForced,
@@ -340,13 +340,13 @@ public:
      * @param tag: optional pointer to receive the extracted tag
      * @param len: optional pointer to receive the length field after the tag field.
      *             This gives the length of the previous hashsed element name starting
-     *             from the begining of the give element name.
+     *             from the beginning of the give element name.
      * @param postfix: optional pointer to receive the postfix starting at the found tag field.
      * @param type: optional pointer to receive the element type character
      * @param negative: return negative tag as it is. If disabled, then always return positive tag.
-     *                  Negative tag is sometimes used for element disambiguiation.
+     *                  Negative tag is sometimes used for element disambiguation.
      *
-     * @return Return the end poisition of the tag field, or return std::string::npos if not found.
+     * @return Return the end position of the tag field, or return std::string::npos if not found.
      */
     static size_t findTagInElementName(const std::string &name, long *tag=0,
             size_t *len=0, std::string *postfix=0, char *type=0, bool negative=false);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2312,7 +2312,7 @@ Document::readObjects(Base::XMLReader& reader)
         }
     } catch (Base::XMLParseException &e) {
         e.ReportException();
-        FC_ERR("Exception while restroing " << getName() << '.' << objName);
+        FC_ERR("Exception while restoring " << getName() << '.' << objName);
         throw;
     }
     reader.readEndElement("ObjectData");

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -501,7 +501,7 @@ public:
     (const App::DocumentObject* from, const App::DocumentObject* to) const;
     //@}
 
-    /** Called by property during properly save its continaing StringHasher
+    /** Called by property during properly save its containing StringHasher
      *
      * @param hasher: the input hasher
      * @return Returns a pair<bool,int>. Boolean member indicate if the

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -3503,7 +3503,7 @@ Py::Object AssignmentExpression::apply(const Expression *owner, int _catchAll,
             auto e = static_cast<CallableExpression*>(left[0].get());
             info = e->getVarInfo(!!op);
         }else
-            _EXPR_THROW("Invalid assignement",owner);
+            _EXPR_THROW("Invalid assignment",owner);
         if(!op) 
             info.rhs = right->getPyValue();
         else {
@@ -3518,7 +3518,7 @@ Py::Object AssignmentExpression::apply(const Expression *owner, int _catchAll,
     }
 
     if(op)
-        _EXPR_THROW("Invalid argumented assignement",owner);
+        _EXPR_THROW("Invalid argumented assignment",owner);
 
     PyIterable value(right->getPyValue(),owner,true);
     Py::Sequence seq(value);

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -797,7 +797,7 @@ bool isAnyEqual(const App::any &v1, const App::any &v2) {
 
 bool isPyMapping(const Py::Object &obj)
 {
-    // Python3 consider sequence supportin slicing protocol as mapping as well,
+    // Python3 consider sequence supporting slicing protocol as mapping as well,
     // but they do not have keys or values.
     return obj.isMapping() && obj.hasAttr("keys") && obj.hasAttr("values");
 }
@@ -2601,8 +2601,8 @@ const std::vector<FunctionExpression::FunctionInfo> &FunctionExpression::getFunc
         {ATAN, "atan", "Iverse tangent of a value"},
         {ABS, "abs", "Absolute value of a number"},
         {EXP, "exp", "Euler's number raised to a power"},
-        {LOG, "log", "The natural (base e) logrithm of a number"},
-        {LOG10, "log10", "The common (base 10) logrithm of a number"},
+        {LOG, "log", "The natural (base e) logarithm of a number"},
+        {LOG10, "log10", "The common (base 10) logarithm of a number"},
         {SIN, "sin", "Sine of a value"},
         {SINH, "sinh", "Hybolic sine of a value"},
         {TAN, "tan", "Tangent of a value"},
@@ -2622,7 +2622,7 @@ const std::vector<FunctionExpression::FunctionInfo> &FunctionExpression::getFunc
         {LIST, "list", "list(arg...), create a Python list"},
         {TUPLE, "tuple", "tuple(arg...), create a Python tuple"},
         {EVAL, "eval", "eval(arg...), evaluate the first argument (string or sequence of string)\n"
-                       "as expression(s). Additional unamed argument are interpreted as local\n"
+                       "as expression(s). Additional unnamed argument are interpreted as local\n"
                        "variables with name _1_, _2_, and so on. Named argument are interpreted\n"
                        "as variable with the same name."},
         {FUNC, "func", "func(arg...), make a callable object using the first argument (string or\n"
@@ -2644,7 +2644,7 @@ const std::vector<FunctionExpression::FunctionInfo> &FunctionExpression::getFunc
                            "Create a new Python object with the given type.\n"
                            "Currently supported types can be specified as string\n"
                            "with value, vector, matrix, placement or rotation"},
-        {STR, "str", "str(arg), convert the input argment to string"},
+        {STR, "str", "str(arg), convert the input argument to string"},
         {HREF, "href", "href(arg), hide any object reference inside the input.\n"
                        "This allows to create cyclic references. Use with caution!"},
         {DBIND, "dbind", "dbind(arg), double binding a variable expression.\n"
@@ -6849,7 +6849,7 @@ struct Context {
     int bracket_count=0;
     bool line_continue = false;
 
-    // For the sake of performance, we make the followings static
+    // For the sake of performance, we make the following static
     static std::vector<int> IndentStack;
     static std::vector<char> ScannerBuffer; 
 

--- a/src/App/ExpressionParser.l
+++ b/src/App/ExpressionParser.l
@@ -237,7 +237,7 @@ EXPO     [eE][-+]?[0-9]+
 
 #[ \t][^\n]*                _COUNTCHARS; /* in none python mode, comment starts with a space allow document#object syntax */
 
-#\n                         yyless(yyleng-1); _COUNTCHARS; /* comment with immedate newline */
+#\n                         yyless(yyleng-1); _COUNTCHARS; /* comment with immediate newline */
 
 ^[ \t]*#([ \t]+\n|\n)       /* comment only line */ ctx.column=0; ctx.line_continue=false; 
 

--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -178,9 +178,9 @@ public:
         return false;
     }
 
-    /** Invoke a callable for each extenions of a given type
+    /** Invoke a callable for each extension of a given type
      * @param f: the callable that accepts one argument of an extension, and
-     * returns any value that is convertable to boolean.
+     * returns any value that is convertible to boolean.
      *
      * @return Returns true if the iteratorion is terminated prematurely, or else false.
      *

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -193,7 +193,7 @@ void GeoFeatureGroupExtension::buildExport(
     // attached (e.g. Gui module is not loaded), we rely on the following logic
     // to include only children that do not appear in the inList of any other
     // child. This logic is similar to ViewProviderGeoFeatureGroupExtension,
-    // but not exactly the same.  So there may have some discrepency depending
+    // but not exactly the same.  So there may have some discrepancy depending
     // on whether the Gui module is loaded or not.
     if(owner->testStatus(ObjectStatus::ViewProviderAttached))
         return;

--- a/src/App/GroupExtension.h
+++ b/src/App/GroupExtension.h
@@ -145,7 +145,7 @@ public:
     };
     PropertyEnumeration ExportMode;
 
-    /// Helper class to temperary enable old group visibility toggling behavior
+    /// Helper class to temporary enable old group visibility toggling behavior
     struct AppExport ToggleNestedVisibility {
         ToggleNestedVisibility();
         ~ ToggleNestedVisibility();

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -849,7 +849,7 @@ ObjectIdentifier::Component::MapComponent(String &&_key)
 
 /**
  * @brief Create a range component with given begin and end.
- * @param _begin begining index of the range
+ * @param _begin beginning index of the range
  * @param _end ending index of the range
  * @return A new Component object.
  */
@@ -1100,7 +1100,7 @@ void ObjectIdentifier::resolve(ResolveResults &results) const
                     int ptype;
                     Property *prop = resolveProperty(owner,tmpSub,pindex,sobj,ptype);
                     if(prop) {
-                        // If we found sub object in previous attemp, look further
+                        // If we found sub object in previous attempt, look further
                         // to see which one has the better match
                         if(results.propertyType == PseudoSubObject && pindex+1 < (int)components.size()) {
                             Base::PyGILStateLocker lock;
@@ -1113,7 +1113,7 @@ void ObjectIdentifier::resolve(ResolveResults &results) const
                                 return;
                             } catch (...) {
                                 // Exception here means the sub-object
-                                // intepretation is a better match, so return
+                                // interpretation is a better match, so return
                                 // early. 
                                 return;
                             }

--- a/src/App/ObjectIdentifier.h
+++ b/src/App/ObjectIdentifier.h
@@ -383,7 +383,7 @@ public:
 
     /** Get dependencies of this object identifier
      *
-     * @param deps: returns the depdenencies.
+     * @param deps: returns the dependencies.
      * @param needProps: whether need property dependencies.
      * @param labels: optional return of any label references.
      *

--- a/src/App/OriginGroupExtension.h
+++ b/src/App/OriginGroupExtension.h
@@ -61,7 +61,7 @@ public:
     /// Origin linked to the group
     PropertyLink Origin;
     
-    //changes all links of obj to a origin to point to this groupes origin
+    //changes all links of obj to a origin to point to this groups origin
     void relinkToOrigin(App::DocumentObject* obj);
     
     virtual std::vector<DocumentObject*> addObjects(std::vector<DocumentObject*> obj) override;

--- a/src/App/Part.h
+++ b/src/App/Part.h
@@ -44,7 +44,7 @@ public:
     PropertyString Type;
 
     /** @name base properties of all Assembly Items
-    * This properties corospond mostly to the meta information
+    * This properties correspond mostly to the meta information
     * in the App::Document class
     */
     //@{

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -499,7 +499,7 @@ protected:
      */
     virtual const char *xmlName() const;
 
-    /// Called to retore the content from the document XML
+    /// Called to restore the content from the document XML
     virtual void restoreXML(Base::XMLReader &) {
         notImplemented();
     }
@@ -521,14 +521,14 @@ protected:
         return false;
     }
 
-    /// Called to save the content into a sperate (file) stream
+    /// Called to save the content into a separate (file) stream
     virtual void restoreStream(Base::InputStream &s, unsigned count) {
         (void)s;
         (void)count;
         notImplemented();
     }
 
-    /// Called to retore the content from a sperate (file) stream
+    /// Called to restore the content from a separate (file) stream
     virtual void saveStream(Base::OutputStream &) const {
         notImplemented();
     }

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -282,7 +282,7 @@ void PropertyContainer::Save (Base::Writer &writer) const
     writer.Stream() << writer.ind() << "<Properties Count=\"" << Map.size()
                     << "\" TransientCount=\"" << transients.size() << "\">\n";
 
-    // First store transient properties to persisit their status value. We use
+    // First store transient properties to persist their status value. We use
     // a new element named "_Property" so that the save file can be opened by
     // older versions of FC.
     writer.incInd();
@@ -405,7 +405,7 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
                         && !status.test(Property::PropTransient)
                         && !prop->testStatus(Property::PropTransient))
                 {
-                    FC_TRACE("restoring proeprty " << prop->getFullName());
+                    FC_TRACE("restoring property " << prop->getFullName());
                     prop->Restore(reader);
                 }else
                     FC_TRACE("skip transient " << prop->getFullName());

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -1083,10 +1083,10 @@ void PropertyExpressionEngine::onRelabeledDocument(const App::Document &doc)
 bool PropertyExpressionEngine::isTouched() const {
     // Document recomputation optimization checks for any touched property to
     // decide whether to call DocumentObject::recompute().
-    // PropertyExpressionEngine is sepecial, as it will always be executed
+    // PropertyExpressionEngine is special, as it will always be executed
     // before DocumentObject::recompute() as long as the object itself is
     // touched. PropertyExpressionEngine::execute() will touch other property if
-    // the expression evalutes to a difference result. So there is no need for
+    // the expression evaluates to a difference result. So there is no need for
     // PropertyExpressionEngine itself to report isTouched().
     
     return false;

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -589,9 +589,9 @@ public:
         bool candelete;
     };
     /** setting the boundaries
-     * This sets the constraint struct. It can be dynamcly 
+     * This sets the constraint struct. It can be dynamincally 
      * allocated or set as an static in the class the property
-     * blongs to:
+     * belongs to:
      * \code
      * const Constraints percent = {0.0,100.0,1.0}
      * \endcode

--- a/src/App/PropertyUnits.h
+++ b/src/App/PropertyUnits.h
@@ -101,7 +101,7 @@ public:
     /** setting the boundaries
      * This sets the constraint struct. It can be dynamically 
      * allocated or set as an static in the class the property
-     * blongs to:
+     * belongs to:
      * \code
      * const Constraints percent = {0.0,100.0,1.0}
      * \endcode

--- a/src/App/StringHasher.cpp
+++ b/src/App/StringHasher.cpp
@@ -221,7 +221,7 @@ void StringHasher::Save(Base::Writer &writer) const {
     } else {
         for(auto &v : _hashes->right) {
             if(_hashes->SaveAll || v.info.getRefCount()>1) {
-                // We are omiting the indentation to save some space in case of long list of hashes
+                // We are omitting the indentation to save some space in case of long list of hashes
                 if(v.info->isHashed()) 
                     writer.Stream() <<"<Item hash=\""<< v.second.toBase64().constData();
                 else if(v.info->isBinary())

--- a/src/App/StringHasher.h
+++ b/src/App/StringHasher.h
@@ -96,9 +96,9 @@ public:
     void setPersistenceFileName(const char *name) const;
     const std::string &getPersistenceFileName() const;
 
-    /** Maps an arbitary string to an integer
+    /** Maps an arbitrary string to an integer
      *
-     * The function maps an arbitary text string to a unique integer ID, which
+     * The function maps an arbitrary text string to a unique integer ID, which
      * is returned as a shared pointer to reference count the ID so that it is
      * possible to prune any unused strings.
      *
@@ -118,7 +118,7 @@ public:
      *
      * This function exists because the stored string may be one way hashed,
      * and the original text is not persistent. The caller use this function to
-     * retieve the reference count ID object after restore
+     * retrieve the reference count ID object after restore
      */
     StringIDRef getID(long id) const;
 

--- a/src/App/lex.ExpressionParser.c
+++ b/src/App/lex.ExpressionParser.c
@@ -11414,7 +11414,7 @@ case 9:
 /* rule 9 can match eol */
 YY_RULE_SETUP
 #line 240 "ExpressionParser.l"
-yyless(yyleng-1); _COUNTCHARS; /* comment with immedate newline */
+yyless(yyleng-1); _COUNTCHARS; /* comment with immediate newline */
 	YY_BREAK
 case 10:
 /* rule 10 can match eol */

--- a/src/App/stx/any.hpp
+++ b/src/App/stx/any.hpp
@@ -189,7 +189,7 @@ public:
             if(this->vtable != nullptr)
             {
                 this->vtable->move(this->storage, rhs.storage);
-                //this->vtable = nullptr; -- uneeded, see below
+                //this->vtable = nullptr; -- unneeded, see below
             }
 
             // move from tmp (previously rhs) to *this.
@@ -230,11 +230,11 @@ private: // Storage and Virtual Method Table
         /// The state of the union after this call is unspecified, caller must ensure not to use src anymore.
         void(*destroy)(storage_union&) BOOST_NOEXCEPT;
 
-        /// Copies the **inner** content of the src union into the yet unitialized dest union.
+        /// Copies the **inner** content of the src union into the yet uninitialized dest union.
         /// As such, both inner objects will have the same state, but on separate memory locations.
         void(*copy)(const storage_union& src, storage_union& dest);
 
-        /// Moves the storage from src to the yet unitialized dest union.
+        /// Moves the storage from src to the yet uninitialized dest union.
         /// The state of src after this call is unspecified, caller must ensure not to use src anymore.
         void(*move)(storage_union& src, storage_union& dest) BOOST_NOEXCEPT;
 
@@ -270,7 +270,7 @@ private: // Storage and Virtual Method Table
 
         static void swap(storage_union& lhs, storage_union& rhs) BOOST_NOEXCEPT
         {
-            // just exchage the storage pointers.
+            // just exchange the storage pointers.
             std::swap(lhs.dynamic, rhs.dynamic);
         }
     };
@@ -348,7 +348,7 @@ protected:
     /// Checks if two type infos are the same.
     ///
     /// If ANY_IMPL_FAST_TYPE_INFO_COMPARE is defined, checks only the address of the
-    /// type infos, otherwise does an actual comparision. Checking addresses is
+    /// type infos, otherwise does an actual comparison. Checking addresses is
     /// only a valid approach when there's no interaction with outside sources
     /// (other shared libraries and such).
     static bool is_same(const std::type_info& a, const std::type_info& b)

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1620,7 +1620,7 @@ void Document::SaveDocFile (Base::Writer &writer) const
         auto obj = getDocument()->getObject(objName.c_str());
         auto it = d->_ViewProviderMap.find(obj);
         if(it == d->_ViewProviderMap.end())
-            FC_ERR("View object not fount: " << getDocument()->getName() << '#' << objName);
+            FC_ERR("View object not found: " << getDocument()->getName() << '#' << objName);
         else {
             writer.Stream() << "<!-- FreeCAD ViewProvider -->\n"
                 << "<Document SchemaVersion=\"" << FC_GUI_SCHEMA_VER 

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -83,8 +83,8 @@ public:
     // The sub-object/pseudo property/property of the owner object is obtained
     // through struct ObjInfo, and cached inside map ExpressionCompleterModel::objMap.
     // Note that at root level, there are two way to reference the own object's
-    // property. The recommanded way is to use a leading '.' for explicit local
-    // proeprty referecing. If use without leading '.', then it may clash with
+    // property. The recommended way is to use a leading '.' for explicit local
+    // property referecing. If use without leading '.', then it may clash with
     // object name.
     //
     // struct Level1Data is used to access children of the root data. The QModelIndex
@@ -113,7 +113,7 @@ public:
     //
     //
     //
-    // For poperty data, Level1Data will generate and save the model data using
+    // For property data, Level1Data will generate and save the model data using
     // struct PropertyData. Note that, once PropertyData is generated, the next
     // time it (or its children) is accessed, it will be through the cached 
     // PropertyData (through ModelIndex lookup of dataMap), instead of Level1Data.
@@ -137,9 +137,9 @@ public:
     // ObjectIdentifier::getPyValue(), and handled the same way as other python
     // attribute values, using struct PythonData.
     //
-    // The subsequent hierarhcy is handled by Level2Data, which is the last
+    // The subsequent hierarchy is handled by Level2Data, which is the last
     // non-physical data, because all both idx fields and the row member are
-    // used up. Further hierarhcies are representd by various concrete model
+    // used up. Further hierarchies are represented by various concrete model
     // data such as ObjectData, PropertyData, and PythonData.
 
 
@@ -459,7 +459,7 @@ public:
                     txt = QObject::tr("Object not found!");
                 else {
                     if(getModel()->inList.count(obj))
-                        txt = QObject::tr("Warning! Cyclic reference may occour if you reference this object\n\n");
+                        txt = QObject::tr("Warning! Cyclic reference may occur if you reference this object\n\n");
                     txt += QString::fromLatin1("%1: %2\n%3: %4").arg(
                             QObject::tr("Internal name"), QString::fromLatin1(obj->getNameInDocument()),
                             QObject::tr("Label"), QString::fromUtf8(obj->Label.getValue()));
@@ -1604,7 +1604,7 @@ public:
             currentPath = std::move(pathString);
 
             // If the last component does not start with '.', it maybe a
-            // list/map index accesor, which cannot be completed.
+            // list/map index accessor, which cannot be completed.
             if(l.last().startsWith(QLatin1Char('.'))) {
                 Base::PyGILStateLocker lock;
                 Py::Object value = vexpr->getPyValue();
@@ -2157,7 +2157,7 @@ QStringList ExpressionCompleter::splitPath ( const QString & input ) const
             }
             break;
         }
-        catch(Py::Exception &) {// shouldn't happend, just to be safe
+        catch(Py::Exception &) {// shouldn't happen, just to be safe
             Base::PyException e;
             FC_TRACE("split path error " << e.what());
             break;

--- a/src/Gui/SoFCSelectionAction.h
+++ b/src/Gui/SoFCSelectionAction.h
@@ -376,7 +376,7 @@ private:
 /** Customized ray pick action
  *
  * It differs from SoRayPickAction in that when it not set to 'PickAll', this
- * action priorities differnt types of primitives with the near same distances,
+ * action priorities different types of primitives with the near same distances,
  * so that it can pick vertex over edge, over face, when the pick points are
  * near the same.
  *

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1130,7 +1130,7 @@ void View3DInventorViewer::checkGroupOnTop(const SelectionChanges &Reason, bool 
 
         if(Reason.Type==SelectionChanges::RmvSelection && alt) {
             // When alt is true, remove this object from the on top group
-            // regardless of whether it is previsouly selected with alt or not.
+            // regardless of whether it is previously selected with alt or not.
             info.alt = false;
             info.clearElements();
         } else {
@@ -1317,7 +1317,7 @@ void View3DInventorViewer::checkGroupOnTop(const SelectionChanges &Reason, bool 
             } else if (det) {
                 // We are preselecting some element. In this case, we do not
                 // use PreSelGroup for highlighting, but instead rely on
-                // OnTopGroup. Becasue we want SoBrepFaceSet to pick the proper
+                // OnTopGroup. Because we want SoBrepFaceSet to pick the proper
                 // highlight color, in case it conflicts with the selection or
                 // the object's original color.
 

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -218,11 +218,11 @@ void View3DInventorPy::init_type()
     add_varargs_method("bindCamera",&View3DInventorPy::bindCamera,
         "bindCamera(node, sync=False)\n\n"
         "Bind a camera node to the camera of this view. Pass 'None' to unbind.\n"
-        "'sync' determins whether to sync the camera setting up on binding.");
+        "'sync' determines whether to sync the camera setting up on binding.");
     add_varargs_method("bindView",&View3DInventorPy::bindView,
         "bindView(view|view_title)\n\n"
         "Bind the camera of the given view to the camera of this view.\n"
-        "'sync' determins whether to sync the camera setting up on binding.");
+        "'sync' determines whether to sync the camera setting up on binding.");
     add_varargs_method("unbindView",&View3DInventorPy::unbindView,
         "unbindView(view|view_title|None)\n\n"
         "Unbind the camera of the given view to the camera of this view.\n"

--- a/src/Mod/Arch/importOBJ.py
+++ b/src/Mod/Arch/importOBJ.py
@@ -175,7 +175,7 @@ def exportSelection(filename, colors=None):
     """exportSelection(filename,colors=None):
 
     New style exporter function called by freecad to export current selection.
-    It is added to allow the function to extract object hierarhcy from the
+    It is added to allow the function to extract object hierarchy from the
     current selection to derived to correct global placement.
 
     filename is the .obj file to export (a .mtl file with same name will also be
@@ -320,7 +320,7 @@ def _export(exportSet, filename, colors):
                         # Recursive mapping of color from group is very complex. We
                         # simply copy the shape to a temporary Part::Feature, and
                         # let its view provider to do the color mapping, which is
-                        # roughly equivalant of invoking Part_SimpleCopy command
+                        # roughly equivalent of invoking Part_SimpleCopy command
                         if not tmpobj:
                             tmpDoc = FreeCAD.newDocument('_ArchTmp', hidden=True, temp=True)
                             try:

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -344,7 +344,7 @@ class Snapper:
 
 
     def cycleSnapObject(self):
-        """Increse the index of the snap object by one."""
+        """Increase the index of the snap object by one."""
         self.snapObjectIndex = self.snapObjectIndex + 1
 
 

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -1914,7 +1914,7 @@ Base::BoundBox3d FemMesh::getBoundBox(void) const
 const std::vector<const char*>& FemMesh::getElementTypes(void) const
 {
     static std::vector<const char*> temp = 
-        {"Vertex", "Edge", "Face", "Volumne"};
+        {"Vertex", "Edge", "Face", "Volume"};
     return temp;
 }
 

--- a/src/Mod/Fem/femtest/test_information.md
+++ b/src/Mod/Fem/femtest/test_information.md
@@ -1,5 +1,5 @@
 # FEM unit test information
-- Find in this fils some informatin how to run unit test for FEM
+- Find in this file some information how to run unit test for FEM
 
 ## more information 
 - how to run a specific test class or a test method see file

--- a/src/Mod/Fem/femviewprovider/view_base_femobject.py
+++ b/src/Mod/Fem/femviewprovider/view_base_femobject.py
@@ -56,7 +56,7 @@ class VPBaseFemObject(object):
             return ""
         if not hasattr(self.Object.Proxy, "Type"):
             FreeCAD.Console.PrintMessage(
-                "{}: Proxy does has not have attribte Type.\n"
+                "{}: Proxy does has not have attribute Type.\n"
                 .format(self.Object.Name)
             )
             return ""

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -805,7 +805,7 @@ void AttachEngine::readLinks(const std::vector<App::DocumentObject*> &objs,
     types.resize(objs.size());
     for (std::size_t i = 0; i < objs.size(); i++) {
         if (!objs[i]->getTypeId().isDerivedFrom(App::GeoFeature::getClassTypeId())) {
-            FC_THROWM(AttachEngineException,"AttachEngine3D: attched to a non App::GeoFeature '"
+            FC_THROWM(AttachEngineException,"AttachEngine3D: attached to a non App::GeoFeature '"
                         << objs[i]->getNameInDocument() << "'");
         }
         App::GeoFeature* geof = static_cast<App::GeoFeature*>(objs[i]);

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -114,7 +114,7 @@ public:
         Frozen = 1, // freeze an external geometry
         Detached = 2, // signal the intentions of detaching the geometry from external reference
         Missing = 3, // geometry with missing external reference
-        Sync = 4, // signal the intension to synchronize a frozen geometry
+        Sync = 4, // signal the intention to synchronize a frozen geometry
     };
     std::bitset<32> Flags;
 

--- a/src/Mod/Part/App/PartFeaturePy.xml
+++ b/src/Mod/Part/App/PartFeaturePy.xml
@@ -21,7 +21,7 @@ getElementHistory(name,recursive=True,sameType=False,showName=False) - returns t
 name: mapped element name belonging to this shape
 recursive: if True, then track back the history through other objects till the origin
 sameType: if True, then stop trace back when element type changes
-showName: if False, return the owner object, or else return a tuple of object name and lable
+showName: if False, return the owner object, or else return a tuple of object name and label
 
 If not recursive, then return tuple(sourceObject, sourceElementName, [intermediateNames...]),
 otherwise return a list of tuple.

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -660,7 +660,7 @@ public:
 
     /** @name sub shape cached functions
      *
-     * These functions uses internal caches for sub shape maps to imporve performance
+     * These functions use internal caches for sub-shape maps to improve performance
      */
     //@{
     void initCache(int reset=0, const char *file=0, int line=0) const;

--- a/src/Mod/Part/App/TopoShapeEx.cpp
+++ b/src/Mod/Part/App/TopoShapeEx.cpp
@@ -2921,7 +2921,7 @@ TopoShape &TopoShape::makESHAPE(const TopoDS_Shape &shape, const Mapper &mapper,
     }
 
     // We shall first exclude those names generated from high level mapping. If
-    // there are still any unamed elements left after we go through the process
+    // there are still any unnamed elements left after we go through the process
     // below, we set delayed=true, and start using those excluded names.
     bool delayed = false;
 
@@ -3050,7 +3050,7 @@ TopoShape &TopoShape::makESHAPE(const TopoDS_Shape &shape, const Mapper &mapper,
         }
 
         // The reverse pass. Starting from the highest level element, i.e.
-        // Face, for any element that are named, assign names for its lower unamed
+        // Face, for any element that are named, assign names for its lower unnamed
         // elements. For example, if Edge1 is named E1, and its vertexes are not
         // named, then name them as E1;U1, E1;U2, etc.
         //

--- a/src/Mod/Part/App/TopoShapeEx.cpp
+++ b/src/Mod/Part/App/TopoShapeEx.cpp
@@ -534,7 +534,7 @@ std::vector<TopoShape> TopoShape::searchSubShape(
     TopAbs_ShapeEnum shapeType = subshape.shapeType();
     switch(shapeType) {
     case TopAbs_VERTEX:
-        // Vertex search will do comparsion with tolerance to account for
+        // Vertex search will do comparison with tolerance to account for
         // rounding error inccured through transformation.
         for(auto &s : getSubTopoShapes(TopAbs_VERTEX)) {
             ++i;
@@ -571,7 +571,7 @@ std::vector<TopoShape> TopoShape::searchSubShape(
         } else
             vertices = subshape.getSubShapes(TopAbs_VERTEX);
 
-        //TODO: no implementation for inifinite edge/face, which does not have vertex
+        //TODO: no implementation for infinite edge/face, which does not have vertex
         if(vertices.empty())
             break;
 
@@ -580,7 +580,7 @@ std::vector<TopoShape> TopoShape::searchSubShape(
         // * Find the ancestor shape of the found vertex
         // * Compare each vertex of the ancestor shape and the input shape
         // * Perform geometry comparison of the ancestor and input shape.
-        //      * For face, perform addition geometry comparsion of each edges.
+        //      * For face, perform addition geometry comparison of each edges.
         std::unordered_set<TopoShape> shapeSet;
         for(auto &v : searchSubShape(vertices[0],nullptr,checkGeometry,tol,atol)) {
             for(auto idx : findAncestors(v.getShape(), shapeType)) {
@@ -2850,7 +2850,7 @@ TopoShape &TopoShape::makESHAPE(const TopoDS_Shape &shape, const Mapper &mapper,
                             newShapes.push_back(xp.Current());
 
                             if((parallelFace<0||coplanarFace<0) && checkParallel>0) {
-                                // Speciallized checking for high level mapped
+                                // Specialized checking for high level mapped
                                 // face that are either coplanar or parallel
                                 // with the source face, which are common in
                                 // operations like extrusion. Once found, the
@@ -2978,7 +2978,7 @@ TopoShape &TopoShape::makESHAPE(const TopoDS_Shape &shape, const Mapper &mapper,
                     if(other_key.shapetype>=3 && first_key.shapetype<3) {
                         // shapetype>=3 means its a high level mapping (e.g. a face
                         // generates a solid). We don't want that if there are more
-                        // precise low level mapping avaialable. See comments above
+                        // precise low level mapping available. See comments above
                         // for more details.
                         break;
                     }
@@ -3691,7 +3691,7 @@ void TopoShape::reTagElementMap(long tag, App::StringHasherRef hasher, const cha
     resetElementMap();
 
     TopLoc_Location loc(tmp._Shape.Location());
-    // Temperary reset shape location to make name mapping faster
+    // Temporary reset shape location to make name mapping faster
     tmp._Shape.Location(TopLoc_Location());
     _Shape.Location(TopLoc_Location());
     mapSubElement(tmp,postfix,!hasher.isNull());

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -119,7 +119,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="comboBoxCommandOverride">
         <property name="toolTip">
-         <string>Override non-PartDesign command with an equivalant PartDesign command when operate on PartDesign feature.</string>
+         <string>Override non-PartDesign command with an equivalent PartDesign command when operate on PartDesign feature.</string>
         </property>
         <property name="currentIndex">
          <number>2</number>
@@ -151,7 +151,7 @@
       <item row="1" column="1">
        <widget class="QComboBox" name="comboBoxWrapFeature">
         <property name="toolTip">
-         <string>If a non-PartDesign object references a PartDesign feature, incoporate the object into PartDesign body using a wrap feature.</string>
+         <string>If a non-PartDesign object references a PartDesign feature, incorporate the object into PartDesign body using a wrap feature.</string>
         </property>
         <property name="currentIndex">
          <number>2</number>

--- a/src/Mod/Part/Gui/SoBrepEdgeSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepEdgeSet.cpp
@@ -239,7 +239,7 @@ void SoBrepEdgeSet::glRender(SoGLRenderAction *action, bool inpath)
             if(!Gui::SoFCSwitch::testTraverseState(Gui::SoFCSwitch::TraverseInvisible)) {
                 // If we are visible, disable transparency to get a solid
                 // outline, or else on top rendering will have some default
-                // transprency, which will give a fainted appearance that is
+                // transparency, which will give a fainted appearance that is
                 // ideal of drawing hidden line, or indicating we are invisible
                 // (but forced to shown by on top rendering)
                 SoLazyElement::setTransparency(state,this,1,&trans,&packer);

--- a/src/Mod/Part/Gui/SoBrepFaceSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.cpp
@@ -1897,7 +1897,7 @@ bool SoBrepFaceSet::VBO::render(SoGLRenderAction * action,
         FC_COIN_THREAD_LOCAL std::vector<unsigned char> vertex_array;
 
         buf.basestripe = sizeof(VertexAttr);
-        // Incase material binding is not overall, we include color into the
+        // In case material binding is not overall, we include color into the
         // VBO, hence plus 4 below. Must do this before calling buf.stripe()
 #ifndef FC_VBO_FORCE_COLOR
         if (mbind != OVERALL)
@@ -2276,7 +2276,7 @@ void SoBrepFaceSet::renderShape(SoGLRenderAction * action) {
             int start = 0;
             int next = 0;
             for(int id : RenderIndices) {
-                // try to render together consequtive indices
+                // try to render together consecutive indices
                 if(next == id) {
                     ++next;
                     continue;

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -1355,7 +1355,7 @@ App::Color ViewProviderPartExt::getElementColor(App::Color color,
         // 'history', but the last entry of 'history' actually contains the real
         // mapped element name of the 'current' modeling step. That's why we are
         // calling getElementHistory() for previous modeling step now, before
-        // retriving the element for the current step using getElementName(),
+        // retrieving the element for the current step using getElementName(),
         // because we need to check intermediate history names of the previous
         // model step. The 'original' returned by getElementHistory() here may
         // or may not contain a valid element name for the previous step. We can

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -143,7 +143,7 @@ public:
     void enableFullSelectionHighlight(bool face=true, bool line=true, bool point=true);
     //@}
 
-    /** @name Color mangement methods 
+    /** @name Color management methods 
      */
     //@{
     virtual void setElementColors(const std::map<std::string,App::Color> &colors) override;

--- a/src/Mod/Part/Gui/ViewProviderPartExtPy.xml
+++ b/src/Mod/Part/Gui/ViewProviderPartExtPy.xml
@@ -25,7 +25,7 @@ Enable/disable full selection highlight for faces, lines, and/or points.
     <Methode Name="mapShapeColors">
         <Documentation>
             <UserDocu>
-mapShapeColors(sourceDoc=None): Update shape colors based on the element map insde the shape
+mapShapeColors(sourceDoc=None): Update shape colors based on the element map inside the shape
 
 sourceDoc: the document of the source object in case the shape comes from another document. 
            If None, then use the owner document

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -272,7 +272,7 @@ std::vector<App::DocumentObject*> Body::addObject(App::DocumentObject *feature)
     // the sketch is based on a feature after the tip.
     //
     // It is only absolutely safe to insert at the very end. We'll have to rely
-    // up on PartGui commands to determin the new object insertion point based
+    // up on PartGui commands to determine the new object insertion point based
     // on user selection at the time of command invoking.
     //
     // insertObject (feature, getNextSolidFeature (), [>after = <] false);

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -839,7 +839,7 @@ void ProfileBased::remapSupportShape(const TopoDS_Shape& newShape)
 #if 1
     (void)newShape;
     // Realthunder: with the new topological naming, I don't think this function
-    // is necessary. A missing element will cause an explicity error, and the
+    // is necessary. A missing element will cause an explicitly error, and the
     // user will be force to manually select the element. Various editors, such
     // as dress up editors, can perform element guessing when activated.
 #else
@@ -1231,7 +1231,7 @@ Base::Vector3d ProfileBased::getProfileNormal(const TopoShape &profileShape) con
         }
     }
 
-    // If the shape is a line, then return an arbitary direction that is perpendicular to the line
+    // If the shape is a line, then return an arbitrary direction that is perpendicular to the line
     auto geom = Part::Geometry::fromShape(shape.getSubShape(TopAbs_EDGE, 1), true);
     auto geomLine = Base::freecad_dynamic_cast<Part::GeomLine>(geom.get());
     if (geomLine) {

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -920,7 +920,7 @@ void SubShapeBinder::onDocumentRestored() {
             && !testStatus(App::ObjectStatus::PartialObject))
     {
         // Older version SubShapeBinder does not treat missing sub object as
-        // error, which may cause noticable error to user. We'll perform an
+        // error, which may cause noticeable error to user. We'll perform an
         // explicit check here, and raise exception if necessary.
         for(auto &l : Support.getSubListValues()) {
             auto obj = l.getValue();

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -289,7 +289,7 @@ bool populateRefElement(App::PropertyLinkSub *prop, QLabel *label, bool canTouch
 
     QString fmt = QString::fromLatin1("%1:%2");
 
-    // Sheck if the element is missing
+    // Check if the element is missing
     bool touched = false;
     if(Data::ComplexGeoData::hasMissingElement(sub.second.c_str())) {
         if(canTouch) {

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -341,7 +341,7 @@ void TaskDressUpParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
                 continue;
             }
             if(element) {
-                showMessage("Ambiguious selection");
+                showMessage("Ambiguous selection");
                 return;
             }
             element = hist.element.c_str();

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
@@ -131,7 +131,7 @@ void TaskFeatureParameters::addNewSolidCheckBox(QWidget *widget)
     if (layout) {
         checkBoxNewSolid = new QCheckBox(widget);
         checkBoxNewSolid->setText(tr("New solid"));
-        checkBoxNewSolid->setToolTip(tr("Make a new seperate solid using this feature"));
+        checkBoxNewSolid->setToolTip(tr("Make a new separate solid using this feature"));
         layout->insertWidget(0, checkBoxNewSolid);
         connect(checkBoxNewSolid, SIGNAL(toggled(bool)), this, SLOT(onNewSolidChanged(bool)));
     }

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -198,7 +198,7 @@ void TaskBoxPrimitives::addNewSolidCheckBox(QWidget *widget)
     if (layout) {
         checkBoxNewSolid = new QCheckBox(widget);
         checkBoxNewSolid->setText(tr("New solid"));
-        checkBoxNewSolid->setToolTip(tr("Make a new seperate solid using this feature"));
+        checkBoxNewSolid->setToolTip(tr("Make a new separate solid using this feature"));
         layout->insertWidget(0, checkBoxNewSolid);
         connect(checkBoxNewSolid, SIGNAL(toggled(bool)), this, SLOT(onNewSolidChanged(bool)));
     }

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -595,11 +595,11 @@ PartDesign::Body *queryCommandOverride()
     if (sels.empty())
         box.setText(QObject::tr("You are invoking a non-PartDesign command while referecing a "
                                 "PartDesign feature.\n\nDo you want to override this command with "
-                                "an equivalant PartDesign command?"));
+                                "an equivalent PartDesign command?"));
     else
         box.setText(QObject::tr("You are invoking a non-PartDesign command while having an active"
                                 "PartDesign body.\n\nDo you want to override this command with an "
-                                "equivalant PartDesign command?"));
+                                "equivalent PartDesign command?"));
     box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     box.setDefaultButton(QMessageBox::Yes);
     box.setEscapeButton(QMessageBox::No);
@@ -789,7 +789,7 @@ public:
             box.setIcon(QMessageBox::Question);
             box.setWindowTitle(QObject::tr("PartDesign feature wrap"));
             box.setText(QObject::tr("You are referencing a PartDesign feature in a non-PartDesign "
-                                    "object.\n\nDo you want to incoporate this object into PartDesign "
+                                    "object.\n\nDo you want to incorporate this object into PartDesign "
                                     "body using a wrap feature?"));
             box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
             box.setDefaultButton(QMessageBox::Yes);

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -176,7 +176,7 @@ void ViewProviderTransformed::recomputeFeature(bool recompute)
         if (rejected>0) {
             msg = QString::fromLatin1("<font color='orange'>%1</font>");
             if (rejected == 1)
-                msg = msg.arg(QObject::tr("One transformed shape is cuasing error"));
+                msg = msg.arg(QObject::tr("One transformed shape is causing error"));
             else {
                 msg = msg.arg(QObject::tr("%1 transformed shapes are causing error"));
                 msg = msg.arg(rejected);

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -523,7 +523,7 @@ void SketchObject::generateId(Part::Geometry *geo) {
     if(!geoHistory)
         updateGeoHistory();
 
-    // Search geo histroy to see if the start point and end point belongs to
+    // Search geo history to see if the start point and end point belongs to
     // some deleted geometries. Prefer matching both start and end point. If
     // can't then try start and then end. Generate new id if none is found.
     auto pstart = getPoint(geo,start);
@@ -6539,7 +6539,7 @@ void SketchObject::rebuildExternalGeometry(bool defining)
                                         P2 = ProjPointOnPlane_XYZ(pntL, sketchPlane);
                                         // P1 = P1, already defined
                                     } else {
-                                        // P1 = P1, alreday defined
+                                        // P1 = P1, already defined
                                         // P2 = P2, already defined
                                     }
                                 } else {

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -5664,7 +5664,7 @@ void ViewProviderSketch::updateData(const App::Property *prop)
     // watch for. On the other hand, performing a recomputation (done in
     // onUndoRedoFinished()) is not a good idea, as it may affects multiple
     // objects and causing an inconsistent undo/redo state, which is why
-    // recomputation is now forbiden during udno/redo by the core.)
+    // recomputation is now forbidden during undo/redo by the core.)
 #if 0
     if (edit && !getSketchObject()->getDocument()->isPerformingTransaction()
              && !getSketchObject()->isPerformingInternalTransaction()
@@ -6748,7 +6748,7 @@ bool ViewProviderSketchExport::doubleClicked(void) {
                             App::GeoFeatureGroupExtension::getExtensionClassTypeId()))
                     group = feat;
                 const char *subname = sel.SubName;
-                // Walk down the object hierachy in SubName to find the sketch
+                // Walk down the object hierarchy in SubName to find the sketch
                 for(const char *dot=strchr(subname,'.');dot;subname=dot+1,dot=strchr(subname,'.')) {
                     std::string name(subname,dot-subname+1);
                     auto sobj = feat->getSubObject(name.c_str());

--- a/src/Mod/Spreadsheet/App/SheetPy.xml
+++ b/src/Mod/Spreadsheet/App/SheetPy.xml
@@ -207,7 +207,7 @@ Enable/Disable given spreadsheet cell persistent edit mode.</UserDocu>
 recomputeCells(from, to=None)
 
 Manually recompute cells in the given range with the given order without
-following depedency order.
+following dependency order.
         </UserDocu>
       </Documentation>
     </Methode>

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -173,7 +173,7 @@ SheetTableView::SheetTableView(QWidget *parent)
     contextMenu->addAction(recomputeOnly);
     recomputeOnly->setToolTip(tr("Recompute only the selected cells without touching other depending cells\n"
                                  "It can be used as a way out of tricky cyclic dependency problem, but may\n"
-                                 "may affect cells depedency coherence. Use with care!"));
+                                 "may affect cells dependency coherence. Use with care!"));
 
     contextMenu->addSeparator();
 

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -223,7 +223,7 @@ void QGIFace::loadSvgHatch(std::string fileSpec)
     }
     m_svgXML = f.readAll();
 
-    // search in the file for the "stroke" specifiction in order to find out what declaration style is used
+    // search in the file for the "stroke" specification in order to find out what declaration style is used
     // this is necessary to apply a color set by the user to the SVG
     QByteArray pattern("stroke:");
     QByteArrayMatcher matcher(pattern);


### PR DESCRIPTION
Found via `codespell v2.0.dev`  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```