### PR TITLE
Gui: reconfigure long_click action as "Set Rotation Center"

### DIFF
--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -419,7 +419,7 @@ public:
             //all buttons released
             if (long_click){
                 //emulate RMB-click
-                ns.openPopupMenu(ev.inventor_event->getPosition());
+                ns.onSetRotationCenter(ev.inventor_event->getPosition());
                 return transit<NS::IdleState>();
             } else {
                 //refire all events && return to idle state


### PR DESCRIPTION
Related to #94. 

Checklist:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`  (Not passing, but I *think* it's not related with this PR)
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

