### PR TITLE
Don't use built-in std::any on any libc++ system (not just Apple)

### DIFF
--- a/src/App/stx/any.hpp
+++ b/src/App/stx/any.hpp
@@ -36,7 +36,7 @@
 #define STX_NO_STD_ANY
 #endif
 
-#if defined(__has_include) && !defined(STX_NO_STD_ANY) && !defined(__APPLE_CC__)
+#if defined(__has_include) && !defined(STX_NO_STD_ANY) && !defined(__APPLE_CC__) && !defined(_LIBCPP_VERSION)
 #    if __has_include(<any>) && (__cplusplus > 201402)
 #       include <any>
         namespace STX_NAMESPACE_NAME {


### PR DESCRIPTION
This fixes the build, which was failing with not being able to find the `empty` method. (Which, btw, is [not part of the final standard](https://en.cppreference.com/w/cpp/utility/any) so this should be done differently in general.)