### PR TITLE
GUI: Quick fix for Expression Editor text color being black instead of white in dark themes

### DIFF
--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -99,7 +99,7 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
     bool darkstyle = mainstyle.indexOf(QLatin1String("dark"),0,Qt::CaseInsensitive) >= 0;
     if (darkstyle) {
         this->stylesheet = QLatin1String("*{color:palette(bright-text)}");
-        ui->expression->setStyleSheet(QLatin1String("margin:0px; color:black"));
+        ui->expression->setStyleSheet(QLatin1String("margin:0px; color:white"));
     } else {
         this->stylesheet = QLatin1String("*{color:palette(text)}");
         ui->expression->setStyleSheet(QLatin1String("margin:0px"));


### PR DESCRIPTION
Quick fix for this issue: https://github.com/realthunder/FreeCAD_assembly3/issues/787

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

I could only run the base test suite because of unrelated pending issues on the branch, visually confirmed to work with all stock dark themes.