### PR TITLE
Gui: New and enhanced color selection logic for Expression Input Dialog

### DIFF
--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -581,23 +581,61 @@ void ProxyWidget::paintEvent(QPaintEvent *)
     painter.drawRoundedRect(0, 0, width()-1, 8, 3, 3);
 }
 
-//Notification functions to flip flags indicating which proprties have been set by the style sheet
-void DlgExpressionInput::ssTextColor() { hasTextColor = true; }
-void DlgExpressionInput::ssLogColor() { hasLogColor = true; }
-void DlgExpressionInput::ssWarningColor() { hasWarningColor = true; }
-void DlgExpressionInput::ssErrorColor() { hasErrorColor = true; }
+//Accessors to flip flags indicating which proprties have been set by the style sheet
+//Setters
+void DlgExpressionInput::setIgnoreOutputWindowColors(bool flag) {
+    this->_ignoreOutputWindowColors = flag;
+}
+void DlgExpressionInput::setTextColor(QColor color) { 
+    this->_textColor = color;
+    this->hasTextColor = true;
+}
+void DlgExpressionInput::setLogColor(QColor color) { 
+    this->_logColor = color;
+    this->hasLogColor = true;
+}
+void DlgExpressionInput::setWarningColor(QColor color) { 
+    this->_warningColor = color;
+    this->hasWarningColor = true;
+}
+void DlgExpressionInput::setErrorColor(QColor color) {
+    this->_errorColor = color;
+    this->hasErrorColor = true;
+}
+void DlgExpressionInput::setTextBackgroundColor(QColor color) { 
+    this->_textBackgroundColor = color;
+    this->hasTextBackgroundColor = true;
+}
+void DlgExpressionInput::setLogBackgroundColor(QColor color) {
+    this->_logBackgroundColor = color;
+    this->hasLogBackgroundColor = true;
+}
+void DlgExpressionInput::setWarningBackgroundColor(QColor color) {
+    this->_warningBackgroundColor = color;
+    this->hasWarningBackgroundColor = true;
+}
+void DlgExpressionInput::setErrorBackgroundColor(QColor color) {
+    this->_errorBackgroundColor = color;
+    this->hasErrorBackgroundColor = true;
+}
 
-void DlgExpressionInput::ssTextBackgroundColor() { hasTextBackgroundColor = true; }
-void DlgExpressionInput::ssLogBackgroundColor() { hasLogBackgroundColor = true; }
-void DlgExpressionInput::ssWarningBackgroundColor() { hasWarningBackgroundColor = true; }
-void DlgExpressionInput::ssErrorBackgroundColor() { hasErrorBackgroundColor = true; }
+//Getters
+bool DlgExpressionInput::ignoreOutputWindowColors() const { return this->_ignoreOutputWindowColors; }
+QColor DlgExpressionInput::textColor() const { return this->_textColor; }
+QColor DlgExpressionInput::logColor() const { return this->_logColor; }
+QColor DlgExpressionInput::warningColor() const { return this->_warningColor; }
+QColor DlgExpressionInput::errorColor() const { return this->_errorColor; }
+QColor DlgExpressionInput::textBackgroundColor() const { return this->_textBackgroundColor; }
+QColor DlgExpressionInput::logBackgroundColor() const { return this->_logBackgroundColor; }
+QColor DlgExpressionInput::warningBackgroundColor() const { return this->_warningBackgroundColor ; }
+QColor DlgExpressionInput::errorBackgroundColor() const { return this->_errorBackgroundColor; }
 
-//Does all the work related to picking up colors and preparing the style stings for later use
-//Has hardcoded default values, so might consider lifing those from somewhere else in the future
+//Does all the work related to picking up colors and preparing the style strings for later use
+//Has hardcoded default values, so might consider lifting those from somewhere else in the future
 void DlgExpressionInput::setupColors()
 {
     //Forces qProperties evaluation for use in color priority logic
-    //Since this is called at the very end of the constructor there should be no difference with normal run
+    //Since this is called at the very end of the constructor there should be no difference with a normal run
     this->ensurePolished();
 
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
@@ -636,28 +674,28 @@ void DlgExpressionInput::setupColors()
                            hasStyleSheet, isDarkStyle, this->hasTextColor, this->hasTextBackgroundColor,
                            qRgba(255, 255, 255, 255), qRgba(28, 28, 28, 179), //dark colors
                            qRgba(0, 0, 0, 228), qRgba(255, 255, 255, 200), //light colors
-                           &_textColor, &_textBackgroundColor);
+                           &this->textColor(), &this->textBackgroundColor());
 
     this->logColorStyle = colorPriority(userLogColor, defaultLogColor, 
                           hasStyleSheet, isDarkStyle, this->hasLogColor, this->hasLogBackgroundColor,
                           qRgba(96, 205, 255, 179), qRgba(28, 28, 28, 179), //dark colors
                           qRgba(0, 95, 183, 200), qRgba(255, 255, 255, 200), //light colors
-                          &_logColor, &_logBackgroundColor);
+                          &this->logColor(), &this->logBackgroundColor());
 
     this->warningColorStyle = colorPriority(userWarningColor, defaultWarningColor, 
                               hasStyleSheet, isDarkStyle, this->hasWarningColor, this->hasWarningBackgroundColor,
                               qRgba(252, 225, 0, 179), qRgba(28, 28, 28, 179), //dark colors
                               qRgba(157, 93, 0, 200), qRgba(255, 255, 255, 200), //light colors
-                              &_warningColor, &_warningBackgroundColor);
+                              &this->warningColor(), &this->warningBackgroundColor());
 
     this->errorColorStyle = colorPriority(userErrorColor, defaultErrorColor, 
                             hasStyleSheet, isDarkStyle, this->hasErrorColor, this->hasErrorBackgroundColor,
                             qRgba(255, 153, 164, 179), qRgba(28, 28, 28, 179), //dark colors
                             qRgba(198, 43, 28, 200), qRgba(255, 255, 255, 200), //light colors
-                            &this->_errorColor, &this->_errorBackgroundColor);
+                            &this->errorColor(), &this->errorBackgroundColor());
 
-    //Old logic to decide the border and background colors of the checkboxes if there no system background is on
-    //I failed to understand excatly *why* this was needed so for now I only removed redundant variables
+    //Logic to decide the border and background colors of the checkboxes if  no system background is on
+    //Needed for OSes that do not support top level transparent windows.
     if (this->noBackground) {
         if (isDarkStyle) {
             this->borderColor.setRgb(0x505050);
@@ -675,8 +713,8 @@ void DlgExpressionInput::setupColors()
     }
 
     //Sets the intial styles on launch and without bound data
-    this->ui->msg->setStyleSheet(textColorStyle);
-    this->ui->expression->setStyleSheet(textColorStyle);
+    this->ui->msg->setStyleSheet(this->textColorStyle);
+    this->ui->expression->setStyleSheet(this->textColorStyle);
 }
 
 QString DlgExpressionInput::colorPriority(QRgb userColor, QRgb fcDefaultColor, 
@@ -689,7 +727,7 @@ QString DlgExpressionInput::colorPriority(QRgb userColor, QRgb fcDefaultColor,
 
     QColor color = QColor::fromRgba(fcDefaultColor);
     //When a user choses specific colors, respect those unless explicitely requested by the style sheet
-    if (userColor != fcDefaultColor && !_ignoreOutputWindowColors) {
+    if (userColor != fcDefaultColor && !this->ignoreOutputWindowColors()) {
         color = QColor::fromRgba(userColor);
     }
     //When a style sheet is used without explicit support, override with readable colors

--- a/src/Gui/DlgExpressionInput.h
+++ b/src/Gui/DlgExpressionInput.h
@@ -74,19 +74,19 @@ class GuiExport DlgExpressionInput : public QDialog
     }
     */
 
-    Q_PROPERTY(bool ignoreOutputWindowColors MEMBER _ignoreOutputWindowColors)
+    Q_PROPERTY(bool ignoreOutputWindowColors READ ignoreOutputWindowColors WRITE setIgnoreOutputWindowColors)
 
-    Q_PROPERTY(QColor textColor MEMBER _textColor NOTIFY ssTextColor)
-    Q_PROPERTY(QColor textBackgroundColor MEMBER _textBackgroundColor NOTIFY ssTextBackgroundColor)
+    Q_PROPERTY(QColor textColor READ textColor WRITE setTextColor)
+    Q_PROPERTY(QColor textBackgroundColor READ textBackgroundColor WRITE setTextBackgroundColor)
 
-    Q_PROPERTY(QColor logColor MEMBER _logColor NOTIFY ssLogColor)
-    Q_PROPERTY(QColor logBackgroundColor MEMBER _logBackgroundColor NOTIFY ssLogBackgroundColor)
+    Q_PROPERTY(QColor logColor READ logColor WRITE setLogColor)
+    Q_PROPERTY(QColor logBackgroundColor READ logBackgroundColor WRITE setLogBackgroundColor)
 
-    Q_PROPERTY(QColor warningColor MEMBER _warningColor NOTIFY ssWarningColor)
-    Q_PROPERTY(QColor warningBackgroundColor MEMBER _warningBackgroundColor NOTIFY ssWarningBackgroundColor)
+    Q_PROPERTY(QColor warningColor READ warningColor WRITE setWarningColor)
+    Q_PROPERTY(QColor warningBackgroundColor READ warningBackgroundColor WRITE setWarningBackgroundColor)
     
-    Q_PROPERTY(QColor errorColor MEMBER _errorColor NOTIFY ssErrorColor)
-    Q_PROPERTY(QColor errorBackgroundColor MEMBER _errorBackgroundColor NOTIFY ssErrorBackgroundColor)
+    Q_PROPERTY(QColor errorColor READ errorColor WRITE setErrorColor)
+    Q_PROPERTY(QColor errorBackgroundColor READ errorBackgroundColor WRITE setErrorBackgroundColor)
 
 public:
     explicit DlgExpressionInput(const App::ObjectIdentifier & _path, boost::shared_ptr<const App::Expression> _expression, const Base::Unit &_impliedUnit, QWidget *parent = 0);
@@ -100,18 +100,28 @@ public:
 
     bool eventFilter(QObject *obj, QEvent *event);
 
+    void setIgnoreOutputWindowColors(bool flag);
+    void setTextColor(QColor color);
+    void setTextBackgroundColor(QColor color);
+    void setLogColor(QColor color);
+    void setLogBackgroundColor(QColor color);
+    void setWarningColor(QColor color);
+    void setWarningBackgroundColor(QColor color);
+    void setErrorColor(QColor color);
+    void setErrorBackgroundColor(QColor color);
+
+    bool ignoreOutputWindowColors() const;
+    QColor textColor() const;
+    QColor textBackgroundColor() const;
+    QColor logColor() const;
+    QColor logBackgroundColor() const;
+    QColor warningColor() const;
+    QColor warningBackgroundColor() const;
+    QColor errorColor() const;
+    QColor errorBackgroundColor() const;
+
 public Q_SLOTS:
     void show();
-
-public Q_SIGNAL:
-    void ssTextColor();
-    void ssTextBackgroundColor();
-    void ssLogColor();
-    void ssLogBackgroundColor();
-    void ssWarningColor();
-    void ssWarningBackgroundColor();
-    void ssErrorColor();
-    void ssErrorBackgroundColor();
 
 protected:
     void showEvent(QShowEvent*);

--- a/src/Gui/DlgExpressionInput.h
+++ b/src/Gui/DlgExpressionInput.h
@@ -55,6 +55,39 @@ class GuiExport DlgExpressionInput : public QDialog
 {
     Q_OBJECT
 
+     /*
+     Sample style for use in .qss file
+     Colors in sample are not meant to be readable
+     All properties are optional
+     Ignoring Output Window settings might annoy some users, use with caution
+     
+     Gui--Dialog--DlgExpressionInput {
+        qproperty-ignoreOutputWindowColors: true;
+        qproperty-textColor: black;
+        qproperty-textBackgroundColor: white;
+        qproperty-logColor: white;
+        qproperty-logBackgroundColor: blue;
+        qproperty-warningColor: black;
+        qproperty-warningBackgroundColor: yellow;
+        qproperty-errorColor: red;
+        qproperty-errorBackgroundColor: white;
+    }
+    */
+
+    Q_PROPERTY(bool ignoreOutputWindowColors MEMBER _ignoreOutputWindowColors)
+
+    Q_PROPERTY(QColor textColor MEMBER _textColor NOTIFY ssTextColor)
+    Q_PROPERTY(QColor textBackgroundColor MEMBER _textBackgroundColor NOTIFY ssTextBackgroundColor)
+
+    Q_PROPERTY(QColor logColor MEMBER _logColor NOTIFY ssLogColor)
+    Q_PROPERTY(QColor logBackgroundColor MEMBER _logBackgroundColor NOTIFY ssLogBackgroundColor)
+
+    Q_PROPERTY(QColor warningColor MEMBER _warningColor NOTIFY ssWarningColor)
+    Q_PROPERTY(QColor warningBackgroundColor MEMBER _warningBackgroundColor NOTIFY ssWarningBackgroundColor)
+    
+    Q_PROPERTY(QColor errorColor MEMBER _errorColor NOTIFY ssErrorColor)
+    Q_PROPERTY(QColor errorBackgroundColor MEMBER _errorBackgroundColor NOTIFY ssErrorBackgroundColor)
+
 public:
     explicit DlgExpressionInput(const App::ObjectIdentifier & _path, boost::shared_ptr<const App::Expression> _expression, const Base::Unit &_impliedUnit, QWidget *parent = 0);
     ~DlgExpressionInput();
@@ -69,7 +102,16 @@ public:
 
 public Q_SLOTS:
     void show();
-    void applyStylesheet();
+
+public Q_SIGNAL:
+    void ssTextColor();
+    void ssTextBackgroundColor();
+    void ssLogColor();
+    void ssLogBackgroundColor();
+    void ssWarningColor();
+    void ssWarningBackgroundColor();
+    void ssErrorColor();
+    void ssErrorBackgroundColor();
 
 protected:
     void showEvent(QShowEvent*);
@@ -102,11 +144,33 @@ private:
 
     QColor borderColor;
     QColor backgroundColor;
-    QString stylesheet;
-    QString msgStyle;
-    QString colorLog;
-    QString colorError;
-    QString colorWarning;
+
+    QString textColorStyle;
+    QColor _textColor;
+    QColor _textBackgroundColor;
+
+    QString logColorStyle;
+    QColor _logColor;
+    QColor _logBackgroundColor;
+
+    QString warningColorStyle;
+    QColor _warningColor;
+    QColor _warningBackgroundColor;
+
+    QString errorColorStyle;
+    QColor _errorColor;
+    QColor _errorBackgroundColor;
+
+    bool _ignoreOutputWindowColors = false;
+
+    bool hasTextColor = false;
+    bool hasLogColor = false;
+    bool hasWarningColor = false;
+    bool hasErrorColor = false;
+    bool hasTextBackgroundColor = false;
+    bool hasLogBackgroundColor = false;
+    bool hasWarningBackgroundColor = false;
+    bool hasErrorBackgroundColor = false;
 
     bool adjustingPosition = false;
     bool noBackground;
@@ -119,6 +183,14 @@ private:
     friend class ProxyWidget;
 
     App::ExpressionFunctionCallDisabler exprFuncDisabler;
+
+    void setupColors();
+    QString colorPriority(QRgb userColor, QRgb fcDefaultColor, 
+                          bool hasStyleSheet, bool isDarkStyle, 
+                          bool hasSsColor, bool hasSsBackgroundColor,
+                          QRgb darkOverrideColor, QRgb darkOverrideBackgroundColor,
+                          QRgb lightOverrideColor, QRgb lightOverrideBackgroundColor,
+                          const QColor *styleSheetColor, const QColor* styleSheetBackgroundColor);
 };
 
 class ProxyWidget : public QWidget


### PR DESCRIPTION
As discussed on #170

In summary, the Expression Input dialog now respects user color choices from Output Window preferences while providing properties for style sheets to add explicit support for the dialog states.

It also handles existing unaware style sheets by using readable default colors both in light and dark mode themes accordingly.

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [x]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

Base unit test ran without error, Visual inspection of all the existing themes to confirm effects as expected.  

Unfortunately only able to test on Windows
