### PR TITLE
Add global commands to hide selected tree items, toggle show hidden tree items

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2849,7 +2849,7 @@ void StdViewBoxZoom::activated(int iMsg)
         View3DInventorViewer* viewer = view->getViewer();
         if (!viewer->isSelecting()) {
             SelectionCallbackHandler::Create(viewer, View3DInventorViewer::BoxZoom, QCursor(QPixmap(cursor_box_zoom), 7, 7));
-		}
+        }
     }
 }
 
@@ -3815,6 +3815,67 @@ void StdTreeDrag::activated(int)
 }
 
 //======================================================================
+// Std_TreeHideSelection
+//======================================================================
+DEF_STD_CMD(StdTreeHideSelection)
+
+StdTreeHideSelection::StdTreeHideSelection()
+    : Command("Std_TreeHideSelection")
+{
+    sGroup = "TreeView";
+    sMenuText = QT_TR_NOOP("Hide item in tree");
+    sToolTipText = QT_TR_NOOP("Hides the selected item in the tree view");
+    sStatusTip = sToolTipText;
+    sWhatsThis = "Std_TreeHideSelection";
+    sPixmap = "tree-item-hide";
+    sAccel = "T,H";
+    eType = 0;
+}
+
+void StdTreeHideSelection::activated(int)
+{
+    if (Gui::Selection().hasSelection()) {
+        for (auto tree : getMainWindow()->findChildren<TreeWidget*>()) {
+            if (tree->isVisible()) {
+                tree->hideSelectedItems();
+                break;
+            }
+        }
+    }
+}
+
+//======================================================================
+// Std_TreeToggleShowHidden
+//======================================================================
+DEF_STD_CMD(StdTreeToggleShowHidden)
+
+StdTreeToggleShowHidden::StdTreeToggleShowHidden()
+	: Command("Std_TreeToggleShowHidden")
+{
+	sGroup = "TreeView";
+	sMenuText = QT_TR_NOOP("Toggle showing hidden items");
+	sToolTipText = QT_TR_NOOP("Toggles whether or not hidden items are visible in the tree");
+	sStatusTip = sToolTipText;
+	sWhatsThis = "Std_TreeToggleShowHidden";
+	sPixmap = "tree-show-hidden";
+	sAccel = "T,S";
+	eType = 0;
+}
+
+void StdTreeToggleShowHidden::activated(int)
+{
+	if (Gui::Selection().hasSelection()) {
+		for (auto tree : getMainWindow()->findChildren<TreeWidget*>()) {
+			if (tree->isVisible()) {
+				tree->toggleShowHiddenItems();
+				break;
+			}
+		}
+	}
+}
+
+
+//======================================================================
 // Std_TreeViewActions
 //===========================================================================
 //
@@ -3848,6 +3909,8 @@ public:
 
         addCommand(new StdTreeDrag(),cmds.size());
         addCommand(new StdTreeSelection(),cmds.size());
+        addCommand(new StdTreeHideSelection());
+        addCommand(new StdTreeToggleShowHidden());
     };
     virtual const char* className() const {return "StdCmdTreeViewActions";}
 };

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3822,14 +3822,14 @@ DEF_STD_CMD(StdTreeHideSelection)
 StdTreeHideSelection::StdTreeHideSelection()
     : Command("Std_TreeHideSelection")
 {
-    sGroup = "TreeView";
-    sMenuText = QT_TR_NOOP("Hide item in tree");
-    sToolTipText = QT_TR_NOOP("Hides the selected item in the tree view");
-    sStatusTip = sToolTipText;
-    sWhatsThis = "Std_TreeHideSelection";
-    sPixmap = "tree-item-hide";
-    sAccel = "T,H";
-    eType = 0;
+    sGroup          = "TreeView";
+    sMenuText       = QT_TR_NOOP("Hide item in tree");
+    sToolTipText    = QT_TR_NOOP("Hides the selected item in the tree view");
+    sStatusTip      = sToolTipText;
+    sWhatsThis      = "Std_TreeHideSelection";
+    sPixmap         = "tree-item-hide";
+    sAccel          = "Ctrl+Shift+H";
+    eType           = 0;
 }
 
 void StdTreeHideSelection::activated(int)
@@ -3852,14 +3852,14 @@ DEF_STD_CMD(StdTreeToggleShowHidden)
 StdTreeToggleShowHidden::StdTreeToggleShowHidden()
 	: Command("Std_TreeToggleShowHidden")
 {
-	sGroup = "TreeView";
-	sMenuText = QT_TR_NOOP("Toggle showing hidden items");
-	sToolTipText = QT_TR_NOOP("Toggles whether or not hidden items are visible in the tree");
-	sStatusTip = sToolTipText;
-	sWhatsThis = "Std_TreeToggleShowHidden";
-	sPixmap = "tree-show-hidden";
-	sAccel = "T,S";
-	eType = 0;
+	sGroup          = "TreeView";
+	sMenuText       = QT_TR_NOOP("Toggle showing hidden items");
+	sToolTipText    = QT_TR_NOOP("Toggles whether or not hidden items are visible in the tree");
+	sStatusTip      = sToolTipText;
+	sWhatsThis      = "Std_TreeToggleShowHidden";
+	sPixmap         = "tree-show-hidden";
+	sAccel          = "Ctrl+Shift+S";
+	eType           = 0;
 }
 
 void StdTreeToggleShowHidden::activated(int)

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -81,6 +81,8 @@
         <file>edit-edit.svg</file>
         <file>edit-cleartext.svg</file>
         <file>tree-item-drag.svg</file>
+        <file>tree-item-hide.svg</file>
+        <file>tree-show-hidden.svg</file>
         <file>tree-goto-sel.svg</file>
         <file>tree-rec-sel.svg</file>
         <file>tree-pre-sel.svg</file>

--- a/src/Gui/Icons/tree-item-hide.svg
+++ b/src/Gui/Icons/tree-item-hide.svg
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64px"
+   height="64px"
+   id="svg3612"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="tree-item-hide.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3614">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Mend"
+       style="overflow:visible;">
+      <path
+         id="path3835"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt;"
+         transform="scale(0.4) rotate(180) translate(10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Mstart"
+       style="overflow:visible">
+      <path
+         id="path3832"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt"
+         transform="scale(0.4) translate(10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible">
+      <path
+         id="path3826"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective3620" />
+    <inkscape:perspective
+       id="perspective3588"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3692"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3144-6">
+      <stop
+         id="stop3146-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3148-2"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3701">
+      <stop
+         id="stop3703"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3705"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3144-6"
+       id="radialGradient3688"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <linearGradient
+       id="linearGradient3708">
+      <stop
+         id="stop3710"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3712"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective3805"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3864-0-0">
+      <stop
+         id="stop3866-5-7"
+         offset="0"
+         style="stop-color:#0619c0;stop-opacity:1;" />
+      <stop
+         id="stop3868-7-6"
+         offset="1"
+         style="stop-color:#379cfb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864-0">
+      <stop
+         id="stop3866-5"
+         offset="0"
+         style="stop-color:#0619c0;stop-opacity:1;" />
+      <stop
+         id="stop3868-7"
+         offset="1"
+         style="stop-color:#379cfb;stop-opacity:1;" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective3902"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="0"
+         id="stop5050" />
+      <stop
+         id="stop5056"
+         offset="0.5"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3841-0-3">
+      <stop
+         id="stop3843-1-3"
+         offset="0"
+         style="stop-color:#0619c0;stop-opacity:1;" />
+      <stop
+         id="stop3845-0-8"
+         offset="1"
+         style="stop-color:#379cfb;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       fy="114.5684"
+       fx="20.892099"
+       r="5.256"
+       cy="114.5684"
+       cx="20.892099"
+       id="aigrd2">
+      <stop
+         id="stop15566"
+         style="stop-color:#F0F0F0"
+         offset="0" />
+      <stop
+         id="stop15568"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         offset="1.0000000" />
+    </radialGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       fy="64.567902"
+       fx="20.892099"
+       r="5.257"
+       cy="64.567902"
+       cx="20.892099"
+       id="aigrd3">
+      <stop
+         id="stop15573"
+         style="stop-color:#F0F0F0"
+         offset="0" />
+      <stop
+         id="stop15575"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         offset="1.0000000" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient15662">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop15664" />
+      <stop
+         style="stop-color:#f8f8f8;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop15666" />
+    </linearGradient>
+    <radialGradient
+       r="86.70845"
+       fy="35.736916"
+       fx="33.966679"
+       cy="35.736916"
+       cx="33.966679"
+       gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4452"
+       xlink:href="#linearGradient259"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient259">
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop260" />
+      <stop
+         style="stop-color:#bbbbbb;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop261" />
+    </linearGradient>
+    <radialGradient
+       r="37.751713"
+       fy="3.7561285"
+       fx="8.824419"
+       cy="3.7561285"
+       cx="8.824419"
+       gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4454"
+       xlink:href="#linearGradient269"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient269">
+      <stop
+         style="stop-color:#a3a3a3;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop270" />
+      <stop
+         style="stop-color:#4c4c4c;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop271" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective4947"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         style="stop-color:#005bff;stop-opacity:1;"
+         offset="0"
+         id="stop4097" />
+      <stop
+         style="stop-color:#c1e3f7;stop-opacity:1;"
+         offset="1"
+         id="stop4099" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective5027"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5076"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4247"
+       id="linearGradient4253"
+       x1="394.15784"
+       y1="185.1304"
+       x2="434.73947"
+       y2="140.22731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)" />
+    <linearGradient
+       id="linearGradient4247">
+      <stop
+         style="stop-color:#2e8207;stop-opacity:1;"
+         offset="0"
+         id="stop4249" />
+      <stop
+         style="stop-color:#52ff00;stop-opacity:1;"
+         offset="1"
+         id="stop4251" />
+    </linearGradient>
+    <linearGradient
+       y2="140.22731"
+       x2="434.73947"
+       y1="185.1304"
+       x1="394.15784"
+       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5087"
+       xlink:href="#linearGradient4247"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5141"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mstart-9"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3832-1"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend-2"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3835-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <linearGradient
+       id="linearGradient3895-5">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897-6" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3094-7-8">
+      <stop
+         id="stop3096-6-7"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop3098-0-4"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2831-2">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop2833-3" />
+      <stop
+         id="stop2855-1"
+         offset="0.33333334"
+         style="stop-color:#5b86be;stop-opacity:1;" />
+      <stop
+         style="stop-color:#83a8d8;stop-opacity:0;"
+         offset="1"
+         id="stop2835-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2380-9">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop2382-4" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop2384-6" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3814"
+       id="radialGradient3820"
+       cx="20.945665"
+       cy="24.73864"
+       fx="20.945665"
+       fy="24.73864"
+       r="26.352777"
+       gradientTransform="matrix(0.49689881,1.3736343,-1.2300244,0.46910229,40.296276,-13.659687)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3814">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3816" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3818" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377"
+       id="radialGradient3868"
+       cx="44.616356"
+       cy="44.709038"
+       fx="44.616356"
+       fy="44.709038"
+       r="16.079004"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0625002,-1.0000002,0.91069082,0.96760906,-43.504641,46.064532)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.359272"
+     inkscape:cx="41.13248"
+     inkscape:cy="30.316022"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="3440"
+     inkscape:window-height="1420"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:pagecheckerboard="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3086"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3617">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[Sebastian Hoogen]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>OpenSCAD_RemoveSubtree</dc:title>
+        <dc:date>2012-05-03</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/OpenSCAD/Resources/icons/OpenSCAD_RemoveSubtree.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g4294-3"
+       transform="translate(2.7790302,-33.031848)">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect4258-1-7-4-3-6"
+         width="26.38888"
+         height="9.9999943"
+         x="21"
+         y="51"
+         rx="0"
+         ry="0" />
+      <rect
+         y="53"
+         x="23"
+         height="6"
+         width="22"
+         id="rect3852-5-5-7"
+         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="g4294-3-5"
+       transform="translate(0.73689359,-1.1438838)">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect4258-1-7-4-3-6-3"
+         width="26.38888"
+         height="9.9999943"
+         x="21"
+         y="51"
+         rx="0"
+         ry="0" />
+      <rect
+         y="53"
+         x="23"
+         height="6"
+         width="22"
+         id="rect3852-5-5-7-5"
+         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       id="path5098-3"
+       d="m 8.999987,12.999998 0,42.000002 12,0"
+       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path5100-6"
+       d="m 23,23 -14.000013,-2e-6"
+       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="ccc"
+       id="path5098-36"
+       d="m 8.999987,12.999998 0,42.000002 12,0"
+       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path5100-7"
+       d="m 24,23 -15.000013,-2e-6"
+       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <rect
+       ry="0"
+       rx="0"
+       y="3"
+       x="3.0000002"
+       height="10"
+       width="37.999989"
+       id="rect4258-1-7-4-5"
+       style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3852-5-3"
+       width="34"
+       height="6"
+       x="5"
+       y="5" />
+    <g
+       id="g4294"
+       transform="translate(8.5333989,-17.066798)">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect4258-1-7-4-3"
+         width="26.38888"
+         height="9.9999943"
+         x="21"
+         y="51"
+         rx="0"
+         ry="0" />
+      <rect
+         y="53"
+         x="23"
+         height="6"
+         width="22"
+         id="rect3852-5-5"
+         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       id="path5098-3-2"
+       d="m 17,24 0,15 12,0"
+       style="fill:none;stroke:#2e3436;stroke-width:5.99999952;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccc"
+       id="path5098-36-6"
+       d="m 17,23 0,16 12,0"
+       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <g
+       id="layer1-3"
+       transform="matrix(0.77278323,0,0,0.77278323,14.405788,-4.79622)">
+      <g
+         id="g3851"
+         transform="matrix(1.1386579,0,0,1.1324894,-5.849948,-6.8720445)">
+        <path
+           style="fill:url(#radialGradient3820);fill-opacity:1;stroke:#2e3436;stroke-width:1.76123;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 7.7722627,34.279354 C 20.354267,58.83915 45.233263,59.243588 58.709426,34.409232 45.894758,9.8013263 21.264446,9.3871781 7.7722627,34.279354 Z"
+           id="path3016" />
+        <circle
+           style="fill:url(#radialGradient3868);fill-opacity:1.0;fill-rule:evenodd;stroke:#204a87;stroke-width:2.00988"
+           id="path3808"
+           transform="matrix(0.87391169,0,0,0.87867175,-0.48055252,1.2209273)"
+           cx="38.586731"
+           cy="37.674473"
+           r="15.074067" />
+        <circle
+           style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2.22435"
+           id="path3810"
+           transform="matrix(0.78964818,0,0,0.79394928,7.0423882,8.1349206)"
+           cx="33.177376"
+           cy="32.986366"
+           r="7.7852244" />
+        <path
+           style="fill:none;stroke:#888a85;stroke-width:1.76123;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 9.5287167,34.283648 C 21.242996,56.504419 44.406199,56.870339 56.95297,34.401158 45.022072,12.136861 22.090404,11.762154 9.5287167,34.283648 Z"
+           id="path3016-7" />
+        <ellipse
+           style="fill:none;stroke:#729fcf;stroke-width:2.31909"
+           id="path3808-0"
+           transform="matrix(0.75739013,0,0,0.76151552,4.0156334,5.6347265)"
+           cx="38.586731"
+           cy="37.674473"
+           rx="15.073794"
+           ry="15.074067" />
+      </g>
+    </g>
+    <g
+       id="g2944"
+       style="fill:none;fill-opacity:1;stroke:#ff0101;stroke-opacity:1;stroke-width:1.8;stroke-miterlimit:4;stroke-dasharray:none;stroke-linecap:round">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ff0101;stroke-width:3.85;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 48,24 59,35"
+         id="path2763" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ff0101;stroke-width:3.85;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 59,24 48,35"
+         id="path2765" />
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/tree-show-hidden.svg
+++ b/src/Gui/Icons/tree-show-hidden.svg
@@ -1,0 +1,709 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64px"
+   height="64px"
+   id="svg3612"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="tree-item-show-hidden.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3614">
+    <linearGradient
+       id="linearGradient6640"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#a4c9d2;stop-opacity:1;"
+         offset="0"
+         id="stop6638" />
+    </linearGradient>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Mend"
+       style="overflow:visible;">
+      <path
+         id="path3835"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt;"
+         transform="scale(0.4) rotate(180) translate(10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Mstart"
+       style="overflow:visible">
+      <path
+         id="path3832"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt"
+         transform="scale(0.4) translate(10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible">
+      <path
+         id="path3826"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective3620" />
+    <inkscape:perspective
+       id="perspective3588"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3692"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3144-6">
+      <stop
+         id="stop3146-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3148-2"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3701">
+      <stop
+         id="stop3703"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3705"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3144-6"
+       id="radialGradient3688"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <linearGradient
+       id="linearGradient3708">
+      <stop
+         id="stop3710"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3712"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective3805"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3864-0-0">
+      <stop
+         id="stop3866-5-7"
+         offset="0"
+         style="stop-color:#0619c0;stop-opacity:1;" />
+      <stop
+         id="stop3868-7-6"
+         offset="1"
+         style="stop-color:#379cfb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864-0">
+      <stop
+         id="stop3866-5"
+         offset="0"
+         style="stop-color:#0619c0;stop-opacity:1;" />
+      <stop
+         id="stop3868-7"
+         offset="1"
+         style="stop-color:#379cfb;stop-opacity:1;" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective3902"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="0"
+         id="stop5050" />
+      <stop
+         id="stop5056"
+         offset="0.5"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3841-0-3">
+      <stop
+         id="stop3843-1-3"
+         offset="0"
+         style="stop-color:#0619c0;stop-opacity:1;" />
+      <stop
+         id="stop3845-0-8"
+         offset="1"
+         style="stop-color:#379cfb;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       fy="114.5684"
+       fx="20.892099"
+       r="5.256"
+       cy="114.5684"
+       cx="20.892099"
+       id="aigrd2">
+      <stop
+         id="stop15566"
+         style="stop-color:#F0F0F0"
+         offset="0" />
+      <stop
+         id="stop15568"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         offset="1.0000000" />
+    </radialGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       fy="64.567902"
+       fx="20.892099"
+       r="5.257"
+       cy="64.567902"
+       cx="20.892099"
+       id="aigrd3">
+      <stop
+         id="stop15573"
+         style="stop-color:#F0F0F0"
+         offset="0" />
+      <stop
+         id="stop15575"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         offset="1.0000000" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient15662">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop15664" />
+      <stop
+         style="stop-color:#f8f8f8;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop15666" />
+    </linearGradient>
+    <radialGradient
+       r="86.70845"
+       fy="35.736916"
+       fx="33.966679"
+       cy="35.736916"
+       cx="33.966679"
+       gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4452"
+       xlink:href="#linearGradient259"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient259">
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop260" />
+      <stop
+         style="stop-color:#bbbbbb;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop261" />
+    </linearGradient>
+    <radialGradient
+       r="37.751713"
+       fy="3.7561285"
+       fx="8.824419"
+       cy="3.7561285"
+       cx="8.824419"
+       gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4454"
+       xlink:href="#linearGradient269"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient269">
+      <stop
+         style="stop-color:#a3a3a3;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop270" />
+      <stop
+         style="stop-color:#4c4c4c;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop271" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective4947"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         style="stop-color:#005bff;stop-opacity:1;"
+         offset="0"
+         id="stop4097" />
+      <stop
+         style="stop-color:#c1e3f7;stop-opacity:1;"
+         offset="1"
+         id="stop4099" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective5027"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5076"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4247"
+       id="linearGradient4253"
+       x1="394.15784"
+       y1="185.1304"
+       x2="434.73947"
+       y2="140.22731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)" />
+    <linearGradient
+       id="linearGradient4247">
+      <stop
+         style="stop-color:#2e8207;stop-opacity:1;"
+         offset="0"
+         id="stop4249" />
+      <stop
+         style="stop-color:#52ff00;stop-opacity:1;"
+         offset="1"
+         id="stop4251" />
+    </linearGradient>
+    <linearGradient
+       y2="140.22731"
+       x2="434.73947"
+       y1="185.1304"
+       x1="394.15784"
+       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5087"
+       xlink:href="#linearGradient4247"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5141"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mstart-9"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3832-1"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend-2"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3835-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <linearGradient
+       id="linearGradient3895-5">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897-6" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3094-7-8">
+      <stop
+         id="stop3096-6-7"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop3098-0-4"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2831-2">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop2833-3" />
+      <stop
+         id="stop2855-1"
+         offset="0.33333334"
+         style="stop-color:#5b86be;stop-opacity:1;" />
+      <stop
+         style="stop-color:#83a8d8;stop-opacity:0;"
+         offset="1"
+         id="stop2835-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2380-9">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop2382-4" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop2384-6" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3814"
+       id="radialGradient3820"
+       cx="20.945665"
+       cy="24.73864"
+       fx="20.945665"
+       fy="24.73864"
+       r="26.352777"
+       gradientTransform="matrix(0.49689881,1.3736343,-1.2300244,0.46910229,40.296276,-13.659687)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3814">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3816" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3818" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377"
+       id="radialGradient3868"
+       cx="44.616356"
+       cy="44.709038"
+       fx="44.616356"
+       fy="44.709038"
+       r="16.079004"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0625002,-1.0000002,0.91069082,0.96760906,-43.504641,46.064532)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6640"
+       id="linearGradient6642"
+       x1="22.507724"
+       y1="37.674473"
+       x2="54.665738"
+       y2="37.674473"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.359272"
+     inkscape:cx="41.13248"
+     inkscape:cy="30.316022"
+     inkscape:current-layer="g3851"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="3440"
+     inkscape:window-height="1420"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:pagecheckerboard="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3086"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3617">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[Sebastian Hoogen]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:date>2012-05-03</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/OpenSCAD/Resources/icons/OpenSCAD_RemoveSubtree.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g4294-3"
+       transform="translate(2.7790302,-33.031848)">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect4258-1-7-4-3-6"
+         width="26.38888"
+         height="9.9999943"
+         x="21"
+         y="51"
+         rx="0"
+         ry="0" />
+      <rect
+         y="53"
+         x="23"
+         height="6"
+         width="22"
+         id="rect3852-5-5-7"
+         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="g4294-3-5"
+       transform="translate(0.73689359,-1.1438838)">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect4258-1-7-4-3-6-3"
+         width="26.38888"
+         height="9.9999943"
+         x="21"
+         y="51"
+         rx="0"
+         ry="0" />
+      <rect
+         y="53"
+         x="23"
+         height="6"
+         width="22"
+         id="rect3852-5-5-7-5"
+         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       id="path5098-3"
+       d="m 8.999987,12.999998 0,42.000002 12,0"
+       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path5100-6"
+       d="m 23,23 -14.000013,-2e-6"
+       style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="ccc"
+       id="path5098-36"
+       d="m 8.999987,12.999998 0,42.000002 12,0"
+       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path5100-7"
+       d="m 24,23 -15.000013,-2e-6"
+       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <rect
+       ry="0"
+       rx="0"
+       y="3"
+       x="3.0000002"
+       height="10"
+       width="37.999989"
+       id="rect4258-1-7-4-5"
+       style="color:#000000;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3852-5-3"
+       width="34"
+       height="6"
+       x="5"
+       y="5" />
+    <g
+       id="g4294"
+       transform="translate(8.5333989,-17.066798)">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;stroke:#2e3436;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect4258-1-7-4-3"
+         width="26.38888"
+         height="9.9999943"
+         x="21"
+         y="51"
+         rx="0"
+         ry="0" />
+      <rect
+         y="53"
+         x="23"
+         height="6"
+         width="22"
+         id="rect3852-5-5"
+         style="fill:#d3d7cf;fill-opacity:1;stroke:#ffffff;stroke-width:1.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       id="path5098-3-2"
+       d="m 17,24 0,15 12,0"
+       style="fill:none;stroke:#2e3436;stroke-width:5.99999952;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccc"
+       id="path5098-36-6"
+       d="m 17,23 0,16 12,0"
+       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       inkscape:connector-curvature="0" />
+    <g
+       id="layer1-3"
+       transform="matrix(0.77278323,0,0,0.77278323,14.405788,-4.79622)">
+      <g
+         id="g3851"
+         transform="matrix(1.1386579,0,0,1.1324894,-5.849948,-6.8720445)">
+        <path
+           style="fill:url(#radialGradient3820);fill-opacity:1;stroke:#2e3436;stroke-width:1.76123;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 7.7722627,34.279354 C 20.354267,58.83915 45.233263,59.243588 58.709426,34.409232 45.894758,9.8013263 21.264446,9.3871781 7.7722627,34.279354 Z"
+           id="path3016" />
+        <circle
+           style="fill:url(#linearGradient6642);fill-opacity:1;fill-rule:evenodd;stroke:#204a87;stroke-width:2.00988"
+           id="path3808"
+           transform="matrix(0.87391169,0,0,0.87867175,-0.48055252,1.2209273)"
+           cx="38.586731"
+           cy="37.674473"
+           r="15.074067" />
+        <circle
+           style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2.22435"
+           id="path3810"
+           transform="matrix(0.78964818,0,0,0.79394928,7.0423882,8.1349206)"
+           cx="33.177376"
+           cy="32.986366"
+           r="7.7852244" />
+        <path
+           style="fill:none;stroke:#888a85;stroke-width:1.76123;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 9.5287167,34.283648 C 21.242996,56.504419 44.406199,56.870339 56.95297,34.401158 45.022072,12.136861 22.090404,11.762154 9.5287167,34.283648 Z"
+           id="path3016-7" />
+        <ellipse
+           style="fill:none;stroke:#729fcf;stroke-width:2.31909"
+           id="path3808-0"
+           transform="matrix(0.75739013,0,0,0.76151552,4.0156334,5.6347265)"
+           cx="38.586731"
+           cy="37.674473"
+           rx="15.073794"
+           ry="15.074067" />
+      </g>
+    </g>
+    <g
+       id="g2944"
+       style="fill:none;fill-opacity:1;stroke:#1cff01;stroke-opacity:1;stroke-width:1.8;stroke-miterlimit:4;stroke-dasharray:none;stroke-linecap:round">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#1cff01;stroke-width:3.85;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 59,25 48,36 42,30"
+         id="path2765" />
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1104,6 +1104,9 @@ TreeWidget::TreeWidget(const char *name, QWidget* parent)
 
     this->showHiddenAction = new QAction(this);
     this->showHiddenAction->setCheckable(true);
+#ifndef Q_OS_MAC
+    this->showHiddenAction->setShortcut(Qt::Key_Control + Qt::Key_Shift + Qt::Key_F3);
+#endif
     connect(this->showHiddenAction, SIGNAL(toggled(bool)),
             this, SLOT(onShowHidden()));
 
@@ -1113,6 +1116,9 @@ TreeWidget::TreeWidget(const char *name, QWidget* parent)
             this, SLOT(onShowTempDoc()));
 
     this->hideInTreeAction = new QAction(this);
+#ifndef Q_OS_MAC
+    this->hideInTreeAction->setShortcut(Qt::Key_Control + Qt::Key_F3);
+#endif
     this->hideInTreeAction->setCheckable(true);
     connect(this->hideInTreeAction, SIGNAL(toggled(bool)),
             this, SLOT(onHideInTree()));

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1104,9 +1104,6 @@ TreeWidget::TreeWidget(const char *name, QWidget* parent)
 
     this->showHiddenAction = new QAction(this);
     this->showHiddenAction->setCheckable(true);
-#ifndef Q_OS_MAC
-    this->showHiddenAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_F3);
-#endif
     connect(this->showHiddenAction, SIGNAL(toggled(bool)),
             this, SLOT(onShowHidden()));
 
@@ -1116,9 +1113,6 @@ TreeWidget::TreeWidget(const char *name, QWidget* parent)
             this, SLOT(onShowTempDoc()));
 
     this->hideInTreeAction = new QAction(this);
-#ifndef Q_OS_MAC
-    this->hideInTreeAction->setShortcut(Qt::CTRL + Qt::Key_F3);
-#endif
     this->hideInTreeAction->setCheckable(true);
     connect(this->hideInTreeAction, SIGNAL(toggled(bool)),
             this, SLOT(onHideInTree()));
@@ -1525,6 +1519,23 @@ void TreeWidget::itemSearch(const QString &text, bool select) {
     {
         FC_TRACE("item " << txt << " search exception in " << doc->getName());
     }
+}
+
+void TreeWidget::hideSelectedItems() {
+	auto sels = this->selectedItems();
+    for (auto& sel : sels) {
+        auto* const item = static_cast<DocumentObjectItem*>(sel);
+        item->object()->ShowInTree.setValue(!item->object()->showInTree());
+    }
+}
+
+void TreeWidget::toggleShowHiddenItems() {
+	auto sels = this->selectedItems();
+	if (sels.size() > 0){
+		auto* const item = static_cast<DocumentObjectItem*>(sels[0]);
+        DocumentItem* const docItem = item->getOwnerDocument();
+        docItem->setShowHidden(!docItem->showHidden());
+	}
 }
 
 Gui::Document *TreeWidget::selectedDocument() {

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1105,7 +1105,7 @@ TreeWidget::TreeWidget(const char *name, QWidget* parent)
     this->showHiddenAction = new QAction(this);
     this->showHiddenAction->setCheckable(true);
 #ifndef Q_OS_MAC
-    this->showHiddenAction->setShortcut(Qt::Key_Control + Qt::Key_Shift + Qt::Key_F3);
+    this->showHiddenAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_F3);
 #endif
     connect(this->showHiddenAction, SIGNAL(toggled(bool)),
             this, SLOT(onShowHidden()));
@@ -1117,7 +1117,7 @@ TreeWidget::TreeWidget(const char *name, QWidget* parent)
 
     this->hideInTreeAction = new QAction(this);
 #ifndef Q_OS_MAC
-    this->hideInTreeAction->setShortcut(Qt::Key_Control + Qt::Key_F3);
+    this->hideInTreeAction->setShortcut(Qt::CTRL + Qt::Key_F3);
 #endif
     this->hideInTreeAction->setCheckable(true);
     connect(this->hideInTreeAction, SIGNAL(toggled(bool)),

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1530,12 +1530,11 @@ void TreeWidget::hideSelectedItems() {
 }
 
 void TreeWidget::toggleShowHiddenItems() {
-	auto sels = this->selectedItems();
-	if (sels.size() > 0){
-		auto* const item = static_cast<DocumentObjectItem*>(sels[0]);
+	auto* const item = static_cast<DocumentObjectItem*>(this->currentItem());
+    if (item) {
         DocumentItem* const docItem = item->getOwnerDocument();
         docItem->setShowHidden(!docItem->showHidden());
-	}
+    }
 }
 
 Gui::Document *TreeWidget::selectedDocument() {

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -124,8 +124,7 @@ public:
                                      App::SubObjectT *resT = nullptr,
                                      bool sync = false,
                                      bool select = false);
-
-    static int iconSize();
+   static int iconSize();
 
     int iconHeight() const;
     void setIconHeight(int height);
@@ -173,6 +172,9 @@ public:
     void resetItemSearch();
     void startItemSearch(QLineEdit*);
     void itemSearch(const QString &text, bool select);
+    void hideSelectedItems();
+    void toggleShowHiddenItems();
+
 
 protected:
     void _selectAllInstances(const ViewProviderDocumentObject &vpd);


### PR DESCRIPTION
This adds global commands to hide selected (single or multiple) tree items, and to toggle whether or not hidden items are shown in the tree.

Currently the only way to do this is right clicking a tree item and selecting the menu item, and it only hides a single item at a time.

The default key bindings are:

* `Ctrl+Shift+H` to hide selected items
* `Ctrl+Shift+S` to toggle showing hidden items

The existing method of using the context/right-click menu is unchanged.

Also added are unique icons for these commands.