### PR TITLE
[Windows] Fixed build for OCC 7.6.0 and Boost 1.78, works with VS2022

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupBoost.cmake
+++ b/cMake/FreeCAD_Helpers/SetupBoost.cmake
@@ -27,5 +27,14 @@ macro(SetupBoost)
                             " ${NO_BOOST_COMPONENTS}\n"
                             "=============================================\n")
     endif(NOT Boost_FOUND)
+    
+    if (WIN32)
+        if (Boost_VERSION VERSION_GREATER_EQUAL "1.78.0")
+            message("-- NOTE: Boost version >= 1.78 and building on Windows: (1) disabling Win32 Regex Localization (2) enabling generic cmath.")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_REGEX_NO_WIN32_LOCALE -DBOOST_CORE_USE_GENERIC_CMATH")
+        endif()
+    endif(WIN32)
+    
+    
 
 endmacro(SetupBoost)

--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
+++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
@@ -66,6 +66,9 @@
 #include <TopTools_DataMapOfShapeShape.hxx>
 #include <TopTools_MapOfShape.hxx>
 #include <TopoDS.hxx>
+#include <BRepBndLib.hxx>
+#include <BRepMesh_IncrementalMesh.hxx>
+#include <TopoDS_Solid.hxx>
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4067)

--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_NETGEN_2D_ONLY.cpp
+++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_NETGEN_2D_ONLY.cpp
@@ -44,6 +44,8 @@
 #include <Standard_ErrorHandler.hxx>
 #include <Standard_Failure.hxx>
 
+#include <TopExp.hxx>
+
 #include <utilities.h>
 
 #include <list>

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2641,7 +2641,7 @@ void Application::LoadParameters(void)
 }
 
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(BOOST_DYN_LINK)
 // fix weird error while linking boost (all versions of VC)
 // VS2010: https://forum.freecadweb.org/viewtopic.php?f=4&t=1886&p=12553&hilit=boost%3A%3Afilesystem%3A%3Aget#p12553
 namespace boost { namespace program_options { std::string arg="arg"; } }

--- a/src/App/StringHasher.cpp
+++ b/src/App/StringHasher.cpp
@@ -26,6 +26,7 @@
 #ifndef _PreComp_
 #endif
 
+#include <deque>
 #include <boost/io/ios_state.hpp>
 #include <boost/iostreams/device/array.hpp>
 #include <boost/iostreams/stream.hpp>

--- a/src/Mod/Fem/App/PreCompiled.h
+++ b/src/Mod/Fem/App/PreCompiled.h
@@ -126,6 +126,7 @@
 #endif
 
 // Opencascade
+#include <Standard_Version.hxx>
 #include <gp_Dir.hxx>
 #include <gp_Lin.hxx>
 #include <gp_Pln.hxx>
@@ -135,7 +136,9 @@
 #include <Bnd_Box.hxx>
 #include <BRep_Tool.hxx>
 #include <BRepAdaptor_Curve.hxx>
+# if OCC_VERSION_HEX < 0x070600
 #include <BRepAdaptor_HSurface.hxx>
+#endif
 #include <BRepAdaptor_Surface.hxx>
 #include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_Copy.hxx>

--- a/src/Mod/Part/App/OpenCascadeAll.h
+++ b/src/Mod/Part/App/OpenCascadeAll.h
@@ -192,8 +192,10 @@
 #include <BRepAdaptor_CompCurve.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepAdaptor_Surface.hxx>
+# if OCC_VERSION_HEX < 0x070600
 #include <BRepAdaptor_HCurve.hxx>
 #include <BRepAdaptor_HCompCurve.hxx>
+#endif
 #include <BRepAlgoAPI_Common.hxx>
 #include <BRepAlgoAPI_Cut.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
@@ -322,7 +324,9 @@
 #include <Geom2d_Line.hxx>
 #include <Geom2d_TrimmedCurve.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
+# if OCC_VERSION_HEX < 0x070600
 #include <Geom2dAdaptor_HCurve.hxx>
+#endif
 #include <Geom2dAPI_ExtremaCurveCurve.hxx>
 #include <Geom2dAPI_InterCurveCurve.hxx>
 #include <Geom2dAPI_Interpolate.hxx>
@@ -360,7 +364,9 @@
 #include <Geom_Plane.hxx>
 #include <Geom_ToroidalSurface.hxx>
 #include <GeomAdaptor.hxx>
+# if OCC_VERSION_HEX < 0x070600
 #include <GeomAdaptor_HCurve.hxx>
+#endif
 #include <GeomAdaptor_Surface.hxx>
 #include <GeomAPI.hxx>
 #include <GeomAPI_ExtremaCurveCurve.hxx>
@@ -430,8 +436,10 @@
 #include <gp_Quaternion.hxx>
 
 // Adaptors
+# if OCC_VERSION_HEX < 0x070600
 #include <Adaptor3d_HCurve.hxx>
 #include <Adaptor3d_HCurveOnSurface.hxx>
+#endif
 
 #include <Approx_Curve3d.hxx>
 
@@ -444,15 +452,19 @@
 #include <HLRAppli_ReflectLines.hxx>
 #include <IntTools_FClass2d.hxx>
 #include <Law_Constant.hxx>
+# if OCC_VERSION_HEX < 0x070600
 #include <MMgt_TShared.hxx>
+#endif
 #include <Message_MsgFile.hxx>
 #include <Precision.hxx>
 #include <UnitsAPI.hxx>
+# if OCC_VERSION_HEX < 0x070600
 #include <Quantity_Factor.hxx>
 #include <Quantity_Length.hxx>
+#include <Quantity_PlaneAngle.hxx>
+#endif
 #include <Quantity_NameOfColor.hxx>
 #include <Quantity_PhysicalQuantity.hxx>
-#include <Quantity_PlaneAngle.hxx>
 #include <Quantity_TypeOfColor.hxx>
 
 // Shape


### PR DESCRIPTION
This corrects the includes for the precompiled headers used on Windows to support OCC 7.6.0, and corrects a few issues presented by the new Boost v1.78 on Windows.

I have successfully compiled with the following libraries:

This software uses open source components whose copyright and other proprietary rights belong to their respective owners:

* Boost 1_78
* Coin3D 4.0.1
* Eigen3 3.4.0
* FreeType 2.11.1
* KDL 
* libarea 
* Open CASCADE Technology 7.6.0
* Point Cloud Library 
* PyCXX 6.2.8
* Python 3.8.6+
* PySide 5.15.0
* Qt 5.15.2
* Salome SMESH 
* Shiboken 5.15.0
* vtk 9.1.0
* Xerces-C 3.2.2
* Zipios++ 
* zlib 1.2.11

The following libraries were recompiled with VS2022:

* Boost
* FreeType 2
* OCC 7.6.0
* VTK 9.1.0

The others were re-used from the asm3 LibPack 12.5.5.

I can create an updated LibPack if desired. Some of the cmake files needed to be modified in the LibPack to ensure libraries and binaries were appropriately found with relative paths.

