### PR TITLE
Add option to use generic visual names for auxiliary groups

### DIFF
--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -101,6 +101,11 @@ public:
 
     PropertyString Label;
     PropertyString Label2;
+
+    /// Allow override for dynamic labels in certain locations (e.g., tree view) by certain object types.
+    virtual const std::string& getVisualLabel() const { return Label.getStrValue(); }
+    virtual const std::string& getVisualLabel2() const { return Label2.getStrValue(); }
+
     PropertyExpressionEngine ExpressionEngine;
 
     /// Allow control visibility status in App name space

--- a/src/Gui/DlgSettingsUI.cpp
+++ b/src/Gui/DlgSettingsUI.cpp
@@ -59,6 +59,7 @@ public:
     FC_UI_CHECKBOX(TreeParams, ResizableColumn,"Resizable columns") \
     FC_UI_CHECKBOX(TreeParams, CheckBoxesSelection,"Show item checkbox") \
     FC_UI_CHECKBOX(TreeParams, HideColumn, "Hide extra column") \
+    FC_UI_CHECKBOX(TreeParams, ShowGenericAuxNames, "Show generic auxillary group names") \
     FC_UI_CHECKBOX(TreeParams, HideScrollBar,"Hide scroll bar") \
     FC_UI_CHECKBOX(TreeParams, HideHeaderView,"Hide header") \
 

--- a/src/Gui/DlgSettingsUI.cpp
+++ b/src/Gui/DlgSettingsUI.cpp
@@ -59,7 +59,7 @@ public:
     FC_UI_CHECKBOX(TreeParams, ResizableColumn,"Resizable columns") \
     FC_UI_CHECKBOX(TreeParams, CheckBoxesSelection,"Show item checkbox") \
     FC_UI_CHECKBOX(TreeParams, HideColumn, "Hide extra column") \
-    FC_UI_CHECKBOX(TreeParams, ShowGenericAuxNames, "Show generic auxillary group names") \
+    FC_UI_CHECKBOX(TreeParams, ShowGenericAuxNames, "Show generic auxiliary group names") \
     FC_UI_CHECKBOX(TreeParams, HideScrollBar,"Hide scroll bar") \
     FC_UI_CHECKBOX(TreeParams, HideHeaderView,"Hide header") \
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -771,7 +771,7 @@ void TreeParams::onHideColumnChanged()
 }
 
 void TreeParams::onShowGenericAuxNamesChanged() {
-    refreshTreeViews();
+    TreeWidget::refreshItemLabels();
 }
 
 TreeParams *TreeParams::instance() {
@@ -4954,6 +4954,22 @@ static QString getItemStatus(const App::SubObjectT objT)
                         "Right click to show children.\n"
                         "Shift + Left click to edit.\n"
                         "Shift + Right click show the edit menu."));
+}
+
+void TreeWidget::refreshItemLabels() {
+    const bool use_generic = TreeParams::ShowGenericAuxNames();
+    
+    for (auto tree : TreeWidget::Instances) {
+        QSignalBlocker blocker(tree);
+        for (QTreeWidgetItemIterator it(tree); *it; ++it) {
+            auto item = *it;
+            if (item->type() == ObjectType) {
+                App::DocumentObject* obj = static_cast<DocumentObjectItem*>(item)->object()->getObject();
+                if (obj) item->setText(0, QString::fromStdString(use_generic ? obj->getVisualLabel() : obj->Label.getStrValue()));
+            }
+        }
+        tree->resizeColumnToContents(0);
+    }
 }
 
 void TreeWidget::populateSelUpMenu(QMenu *menu, const App::SubObjectT *pObjT)

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -124,7 +124,9 @@ public:
                                      App::SubObjectT *resT = nullptr,
                                      bool sync = false,
                                      bool select = false);
-   static int iconSize();
+    static void refreshItemLabels();
+
+    static int iconSize();
 
     int iconHeight() const;
     void setIconHeight(int height);
@@ -159,7 +161,7 @@ public:
     const char *getTreeName() const;
 
     static void updateStatus(bool delay=true);
-
+    
     // Check if obj can be considered as a top level object
     static void checkTopParent(App::DocumentObject *&obj, std::string &subname);
 

--- a/src/Gui/TreeParams.h
+++ b/src/Gui/TreeParams.h
@@ -116,6 +116,8 @@ public:
        QT_TRANSLATE_NOOP("TreeParams", "Tree view item background padding."))\
     FC_TREE_PARAM2(HideColumn,bool,Bool,false, \
        QT_TRANSLATE_NOOP("TreeParams", "Hide extra tree view column for item description."))\
+    FC_TREE_PARAM2(ShowGenericAuxNames,bool,Bool,false, \
+       QT_TRANSLATE_NOOP("TreeParams", "Show generic names for auxillary groups."))\
     FC_TREE_PARAM(HideScrollBar,bool,Bool,true, \
         QT_TRANSLATE_NOOP("TreeParams", "Hide tree view scroll bar in dock overlay"))\
     FC_TREE_PARAM(HideHeaderView,bool,Bool,true, \

--- a/src/Gui/TreeParams.h
+++ b/src/Gui/TreeParams.h
@@ -117,7 +117,7 @@ public:
     FC_TREE_PARAM2(HideColumn,bool,Bool,false, \
        QT_TRANSLATE_NOOP("TreeParams", "Hide extra tree view column for item description."))\
     FC_TREE_PARAM2(ShowGenericAuxNames,bool,Bool,false, \
-       QT_TRANSLATE_NOOP("TreeParams", "Show generic names for auxillary groups."))\
+       QT_TRANSLATE_NOOP("TreeParams", "Show generic names for auxiliary groups."))\
     FC_TREE_PARAM(HideScrollBar,bool,Bool,true, \
         QT_TRANSLATE_NOOP("TreeParams", "Hide tree view scroll bar in dock overlay"))\
     FC_TREE_PARAM(HideHeaderView,bool,Bool,true, \

--- a/src/Mod/PartDesign/App/AuxGroup.cpp
+++ b/src/Mod/PartDesign/App/AuxGroup.cpp
@@ -42,6 +42,11 @@
 using namespace PartDesign;
 namespace bp = boost::placeholders;
 
+// For comparisons and returning a string by reference.
+static const std::string SketchesStr    = "Sketches";
+static const std::string DatumsStr      = "Datums";
+static const std::string MiscStr        = "Misc";
+
 PROPERTY_SOURCE(PartDesign::AuxGroup, App::DocumentObject)
 
 AuxGroup::AuxGroup()
@@ -87,11 +92,11 @@ AuxGroup::GroupType AuxGroup::getGroupType() const
         return groupType;
     if (!getNameInDocument())
         return UnknownGroup;
-    if (boost::starts_with(getNameInDocument(), "Sketches"))
+    if (boost::starts_with(getNameInDocument(), SketchesStr))
         groupType = SketchGroup;
-    else if (boost::starts_with(getNameInDocument(), "Datums"))
+    else if (boost::starts_with(getNameInDocument(), DatumsStr))
         groupType = DatumGroup;
-    else if (boost::starts_with(getNameInDocument(), "Misc"))
+    else if (boost::starts_with(getNameInDocument(), MiscStr))
         groupType = MiscGroup;
     else
         groupType = OtherGroup;
@@ -159,4 +164,12 @@ void AuxGroup::refresh()
         }
     }
     Group.setValues(children);
+}
+
+const std::string& AuxGroup::getVisualLabel() const {
+    return
+        boost::starts_with(getNameInDocument(), SketchesStr) ? SketchesStr :
+        boost::starts_with(getNameInDocument(), DatumsStr) ? DatumsStr :
+        boost::starts_with(getNameInDocument(), MiscStr) ? MiscStr :
+        Label.getStrValue();
 }

--- a/src/Mod/PartDesign/App/AuxGroup.h
+++ b/src/Mod/PartDesign/App/AuxGroup.h
@@ -52,6 +52,9 @@ public:
     virtual void onDocumentRestored() override;
     virtual void onChanged(const App::Property* prop) override;
 
+    // Return generic label if that mode is enabled
+    virtual const std::string& getVisualLabel() const override;
+
     bool isObjectAllowed(const App::DocumentObject *obj) const;
 
     enum GroupType {


### PR DESCRIPTION
This implements the feature I described in Issue #227.

# Visual Auxiliary Naming

This aims to improve visual clarity of the Tree view by visually converting the labels/names of the Auxiliary Groups to their standard names.

For example, `Sketches058` would be visually converted to `Sketches`. 

This improves the visual clarity of the Tree view by removing unnecessary characters and by naming the Auxiliary groups to what they actually are -- general folders for different types of components within a part.

## Notes

A new boolean option is added to the "Tree" section of the UI preferences to disable and enable this new setting.

The actual `Label` member of the `AuxGroup` class is unchanged. It is never assigned to a new value. Instead, the Tree widget accesses a separate function called `getVisualLabel()`. This is a virtual function declared within `DocumentObject`, which normally just returns `Label`. However, in AuxGroup it is overridden to return the generic name.

In this way, the Label member still contains the true name of the object, while a "visual" name can be used. This approach can be expanded upon later if desired.

Modifications were required to the Tree widget -- namely overriding the default "F2" renaming hotkey with one which invokes `onRelabelObject()`, as this is not called on Windows. If the setting is enabled, `onRelabelObject()` then swaps out the existing generic name with the true name, so that the true name can still be modified. After editing/renaming is complete, the modification is stored into `Label`, and the generic name is swapped back in.

Finally, a new static method was added to the Tree widget class which refreshes all of the visual names of the tree view objects of all tree instances. This allows the user to immediately see the effects of the toggling the setting in Preferences, without having to close and reopen a document.

## Example

### Before

![image](https://user-images.githubusercontent.com/19617165/146587863-2c92cab9-a360-4bb2-9860-bbd5ef3d1d0d.png)

### After

![image](https://user-images.githubusercontent.com/19617165/146587883-d5d9ee46-30c8-4822-b26b-ab839430dbc2.png)
