### PR TITLE
Added option to use automatic auxiliary grouping for new bodies.

### DIFF
--- a/src/Gui/TreeParams.h
+++ b/src/Gui/TreeParams.h
@@ -111,7 +111,7 @@ public:
     FC_TREE_PARAM2(ItemSpacing,int,Int,0, \
        QT_TRANSLATE_NOOP("TreeParams", ""))\
     FC_TREE_PARAM2(ItemBackground,unsigned long,Unsigned,0, \
-       QT_TRANSLATE_NOOP("TreeParams", "Tree view item background. Only effecitve in overlay."))\
+       QT_TRANSLATE_NOOP("TreeParams", "Tree view item background. Only effective in overlay."))\
     FC_TREE_PARAM2(ItemBackgroundPadding,int,Int,10, \
        QT_TRANSLATE_NOOP("TreeParams", "Tree view item background padding."))\
     FC_TREE_PARAM2(HideColumn,bool,Bool,false, \

--- a/src/Mod/Part/App/PartParams.h
+++ b/src/Mod/Part/App/PartParams.h
@@ -66,6 +66,7 @@ public:
     FC_APP_PART_PARAM(UseBrepToolsOuterWire, bool, Bool, true) \
     FC_APP_PART_PARAM(UseBaseObjectName,bool,Bool,false) \
     FC_APP_PART_PARAM(AutoGroupSolids,bool,Bool,false) \
+    FC_APP_PART_PARAM(AutoAuxiliaryGrouping,bool,Bool,false) \
     FC_APP_PART_PARAM(SingleSolid,bool,Bool,false) \
     FC_APP_PART_PARAM(UsePipeForExtrusionDraft,bool,Bool,false) \
     FC_APP_PART_PARAM(LinearizeExtrusionDraft,bool,Bool,true) \

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
@@ -63,6 +63,7 @@ void DlgSettingsGeneral::saveSettings()
     ui->comboBoxCommandOverride->onSave();
     ui->comboBoxWrapFeature->onSave();
     ui->checkAutoGroupSolids->onSave();
+    ui->checkAutoAuxiliaryGrouping->onSave();
 }
 
 void DlgSettingsGeneral::loadSettings()
@@ -76,6 +77,7 @@ void DlgSettingsGeneral::loadSettings()
     ui->comboBoxCommandOverride->onRestore();
     ui->comboBoxWrapFeature->onRestore();
     ui->checkAutoGroupSolids->onRestore();
+    ui->checkAutoAuxiliaryGrouping->onRestore();
 }
 
 /**

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -93,7 +93,7 @@ in Part workbench, and equivalent features in PartDesign.</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="Gui::PrefCheckBox" name="checkAutoAuxiliaryGrouping">
          <property name="text">
           <string>Automatic auxiliary grouping for new Bodies</string>

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -88,7 +88,7 @@
       <item row="6" column="0">
        <widget class="Gui::PrefCheckBox" name="checkAutoAuxiliaryGrouping">
          <property name="text">
-          <string>Use auto auxiliary grouping for new Bodies</string>
+          <string>Automatic auxiliary grouping for new Bodies</string>
          </property>
          <property name="prefPath" stdset="0">
           <cstring>Mod/Part</cstring>

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -85,6 +85,19 @@
         </property>
        </widget>
       </item>
+      <item row="6" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkAutoAuxiliaryGrouping">
+         <property name="text">
+          <string>Use auto auxiliary grouping for new Bodies</string>
+         </property>
+         <property name="prefPath" stdset="0">
+          <cstring>Mod/Part</cstring>
+         </property>
+         <property name="prefEntry" stdset="0">
+          <cstring>AutoAuxiliaryGrouping</cstring>
+         </property>
+        </widget>
+      </item>
       <item row="3" column="0">
        <widget class="Gui::PrefCheckBox" name="checkLinearize">
         <property name="toolTip">

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -846,7 +846,7 @@ bool Body::isSolid()
 }
 
 void Body::toggleAutoAuxGrouping() {
-    std::vector<App::DocumentObjectT> groups;
+        std::vector<App::DocumentObjectT> groups;
     for (auto obj : this->Group.getValues()) {
         if (obj->isDerivedFrom(PartDesign::AuxGroup::getClassTypeId())) {
             auto group = static_cast<PartDesign::AuxGroup*>(obj);
@@ -861,10 +861,13 @@ void Body::toggleAutoAuxGrouping() {
             ++pos;
         auto sketchGroup = static_cast<PartDesign::AuxGroup*>(
             this->getDocument()->addObject("PartDesign::AuxGroup", "Sketches"));
+        sketchGroup->Label.setValue("Sketches");
         auto datumGroup = static_cast<PartDesign::AuxGroup*>(
             this->getDocument()->addObject("PartDesign::AuxGroup", "Datums"));
+        datumGroup->Label.setValue("Datums");
         auto miscGroup = static_cast<PartDesign::AuxGroup*>(
             this->getDocument()->addObject("PartDesign::AuxGroup", "Misc"));
+        miscGroup->Label.setValue("Misc");
         children.insert(children.begin() + pos, miscGroup);
         children.insert(children.begin() + pos, datumGroup);
         children.insert(children.begin() + pos, sketchGroup);

--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -198,6 +198,9 @@ public:
     // a body is solid if it has features that are solid according to member isSolidFeature.
     bool isSolid(void);
 
+    // Toggles if auto auxiliary grouping
+    void toggleAutoAuxGrouping();
+
 protected:
     virtual void onSettingDocument() override;
 

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -370,6 +370,9 @@ void CmdPartDesignBody::activated(int iMsg)
         }
     }
 
+    // Toggle auto-aux grouping
+    if (body && Part::PartParams::AutoAuxiliaryGrouping()) body->toggleAutoAuxGrouping();
+
     // if no part feature was there then auto-adjust the camera
     if (viewAll && PartGui::PartParams::AdjustCameraForNewFeature()) {
         Gui::Document* doc = Gui::Application::Instance->getDocument(getDocument());

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -260,6 +260,8 @@ PartDesign::Body * makeBody(App::Document *doc)
         auto gdoc = Gui::Application::Instance->getDocument(doc);
         if (gdoc && gdoc->getActiveView())
             gdoc->getActiveView()->setActiveObject(topParent, PDBODYKEY, topSubName.c_str());
+
+        if (Part::PartParams::AutoAuxiliaryGrouping()) body->toggleAutoAuxGrouping();
     }
     return body;
 }

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -176,41 +176,7 @@ void ViewProviderBody::setupContextMenu(QMenu* menu, QObject* receiver, const ch
                 return;
             App::AutoTransaction committer("Toggle aux group");
             try {
-                std::vector<App::DocumentObjectT> groups;
-                for (auto obj : body->Group.getValues()) {
-                    if (obj->isDerivedFrom(PartDesign::AuxGroup::getClassTypeId())) {
-                        auto group = static_cast<PartDesign::AuxGroup*>(obj);
-                        if (group->getGroupType() != PartDesign::AuxGroup::OtherGroup)
-                            groups.emplace_back(obj);
-                    }
-                }
-                if (groups.empty()) {
-                    int pos = 0;
-                    auto children = body->Group.getValues();
-                    if (children.size() && children[0] == body->BaseFeature.getValue())
-                        ++pos;
-                    auto sketchGroup = static_cast<PartDesign::AuxGroup*>(
-                            body->getDocument()->addObject("PartDesign::AuxGroup", "Sketches"));
-                    auto datumGroup = static_cast<PartDesign::AuxGroup*>(
-                            body->getDocument()->addObject("PartDesign::AuxGroup", "Datums"));
-                    auto miscGroup = static_cast<PartDesign::AuxGroup*>(
-                            body->getDocument()->addObject("PartDesign::AuxGroup", "Misc"));
-                    children.insert(children.begin()+pos, miscGroup);
-                    children.insert(children.begin()+pos, datumGroup);
-                    children.insert(children.begin()+pos, sketchGroup);
-                    body->Group.setValues(children);
-                    sketchGroup->_Body.setValue(body);
-                    datumGroup->_Body.setValue(body);
-                    miscGroup->_Body.setValue(body);
-                } else {
-                    for (auto & objT : groups) {
-                        auto group = static_cast<PartDesign::AuxGroup*>(objT.getObject());
-                        if (group) {
-                            group->_Body.setValue(nullptr);
-                            body->getDocument()->removeObject(group->getNameInDocument());
-                        }
-                    }
-                }
+                body->toggleAutoAuxGrouping();
             } catch (Base::Exception &e) {
                 e.ReportException();
                 QMessageBox::critical(Gui::getMainWindow(), tr("Auto group"),


### PR DESCRIPTION
This is similar to my other PR (#227). 

Instead of having to manually enable auxiliary grouping for each newly created body, this option will automatically toggle and create the auxiliary groups for each newly created body.

It will not retroactively toggle auxiliary grouping for bodies of a document which pre-existed enabling this setting, it will only toggle auxiliary grouping for newly created bodies after this setting is enabled/turned on.
 
The setting was added to the Part workbench settings page, next to the auto-grouping option.