### PR TITLE
snap packaging

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,30 @@
+name: Publish Snap
+
+on:
+  push:
+    tags:
+      - "*" # build for any new tag (on all branches)
+    
+jobs:
+  publish_amd64:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: install snapcraft
+      run: |
+        sudo snap install snapcraft --classic
+        # echo "$STORE_LOGIN" | snapcraft login --with -
+      env:
+        STORE_LOGIN: ${{ secrets.STORE_LOGIN }}
+    # build in destructive mode because building in LXD is way too slow 
+    # due to the kde-neon SDK snap being mounted via fuse
+    - name: build snap 
+      run: sudo snapcraft --destructive-mode
+    - name: upload snap
+      run: |
+        if ${{ endsWith(github.ref, 'edge') }}; then
+          release_to="edge"
+        else
+          release_to="stable"
+        fi
+        sudo snapcraft upload --release=${release_to} freecad-realthunder*.snap

--- a/snap/local/snap-setup-mod/Init.py
+++ b/snap/local/snap-setup-mod/Init.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+pythonpath = os.environ.get("SNAP_PYTHONPATH")
+
+if pythonpath:
+  print(f"Adding snap-specific PYTHONPATH to sys.path: {pythonpath}")
+  os.environ["PYTHONPATH"] = pythonpath
+  for path in pythonpath.split(":"):
+    sys.path.insert(0, path)

--- a/snap/local/stub-chown/meson.build
+++ b/snap/local/stub-chown/meson.build
@@ -1,0 +1,4 @@
+project('stub-chown', 'c')
+src = 'stub-chown.c'
+
+shared_library('stubchown', src, install : true)

--- a/snap/local/stub-chown/stub-chown.c
+++ b/snap/local/stub-chown/stub-chown.c
@@ -1,0 +1,10 @@
+#include <sys/types.h>
+#include <stdio.h>
+
+int chown(const char *pathname,
+          uid_t owner,
+          gid_t group)
+{
+  fprintf(stderr, "stub-chown: Stubbed out attempt to chown '%s'\n", pathname);
+  return 0;
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,299 @@
+name: freecad-realthunder
+base: core20
+adopt-info: freecad
+summary: An open source parametric 3D CAD modeler (realthunder's version)
+description: |
+  FreeCAD is a parametric 3D modeler. Parametric modeling
+  allows you to easily modify your design by going back into
+  your model history and changing its parameters. FreeCAD is
+  open source (LGPL license) and completely modular, allowing
+  for very advanced extension and customization.
+
+  FreeCAD is multiplatfom, and reads and writes many open
+  file formats such as STEP, IGES, STL and others.
+
+  This snap packages the FreeCAD fork of realthunder 
+  (https://github.com/realthunder/FreeCAD/) + the Assembly3 workbench
+  (https://github.com/realthunder/FreeCAD_assembly3).
+
+  Do _not_ complain to upstream about issues with this snap!
+
+  Commands:
+    freecad-realthunder:      Run FreeCAD
+    freecad-realthunder.cmd:  Run FreeCAD command line interface
+    freecad-realthunder.pip:  Install python packages for user (not system-wide). 
+
+grade: devel
+confinement: strict
+compression: lzo
+license: LGPL-2.0-or-later
+
+layout:
+  /usr/share/libdrm/amdgpu.ids:
+    symlink: $SNAP/kf5/usr/share/libdrm/amdgpu.ids
+  /usr/share/openmpi:
+    symlink: $SNAP/usr/share/openmpi
+  /etc/openmpi:
+    bind: $SNAP/etc/openmpi
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/openmpi:
+    bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/openmpi
+  /usr/bin/orted:
+    symlink: $SNAP/usr/bin/orted
+  /etc/matplotlibrc:
+    bind-file: $SNAP/etc/matplotlibrc
+  /usr/share/matplotlib:
+    symlink: $SNAP/usr/share/matplotlib
+  /usr/share/qt5:
+    symlink: $SNAP/kf5/usr/share/qt5
+
+environment:
+  LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack # numpy
+  LD_PRELOAD: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libstubchown.so
+  FREECAD_USER_HOME: $SNAP_USER_COMMON
+  GIT_EXEC_PATH: $SNAP/usr/lib/git-core
+  GIT_TEMPLATE_DIR: $SNAP/usr/share/git-core/templates
+  GIT_CONFIG_NOSYSTEM: 1
+  ELMER_HOME: $SNAP/usr
+  QTWEBENGINE_DISABLE_SANDBOX: 1
+  PYTHONPYCACHEPREFIX: $SNAP_USER_COMMON/.pycache
+  PYTHONUSERBASE: $SNAP_USER_COMMON/.local
+  PIP_USER: 1
+  PYTHONPATH: &pypath $PYTHONUSERBASE/lib/python3.8/site-packages:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages
+  SNAP_PYTHONPATH: *pypath
+
+apps:
+  freecad-realthunder:
+    command: usr/bin/FreeCADLink
+    extensions: [kde-neon]
+    common-id: org.freecadweb.FreeCAD.desktop
+    desktop: freecad_link.desktop
+    plugs: &plugs
+      - home
+      - opengl
+      - removable-media
+      - gsettings
+      - network      
+      - browser-support
+      - unity7
+  cmd:
+    command: usr/bin/FreeCADCmd
+    extensions: [kde-neon]
+    plugs: *plugs
+  pip:
+    command: bin/pip
+    plugs: *plugs
+
+package-repositories:
+  - type: apt
+    ppa: elmer-csc-ubuntu/elmer-csc-ppa
+  - type: apt
+    ppa: openscad/releases
+  - type: apt
+    ppa: freecad-maintainers/occt-releases
+
+parts:
+  stub-chown:
+    plugin: meson
+    source: snap/local/stub-chown
+    meson-parameters:
+      - --prefix=/usr
+
+  snap-setup-mod:
+    plugin: dump
+    source: snap/local/snap-setup-mod
+    organize:
+      "*": usr/Mod/SnapSetup/
+
+  coin3d:
+    plugin: cmake
+    source: https://github.com/realthunder/coin.git
+    source-tag: Coin-20210915 
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCOIN_BUILD_TESTS=OFF
+      - -DCMAKE_CXX_STANDARD=98
+
+  pivy:
+    after: [coin3d]
+    plugin: cmake
+    source: https://github.com/coin3d/pivy.git
+    source-tag: "0.6.6"
+    override-build: |
+      # out of source builds fail for some reason:
+      # https://github.com/coin3d/pivy/issues/72
+      # let's do an in-source build  instead
+      cd $SNAPCRAFT_PART_SRC
+      cmake \
+        -DCMAKE_FIND_ROOT_PATH=/snap/kde-frameworks-5-qt-5-15-3-core20-sdk/current \
+        -DCMAKE_PREFIX_PATH="$SNAPCRAFT_STAGE" \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        .
+      cmake --build . -- -j${SNAPCRAFT_PARALLEL_BUILD_COUNT}
+      DESTDIR="$SNAPCRAFT_PART_INSTALL" cmake --build  . --target install
+
+  freecad:
+    after: [coin3d, pivy]
+    plugin: cmake
+    source: .
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DBUILD_QT5=ON
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DPYTHON_EXECUTABLE=/usr/bin/python3
+      - -DPYTHON_INCLUDE_DIR=/usr/include/python3.8
+      - -DPYTHON_LIBRARY=/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libpython3.8.so
+      - -DFREECAD_USE_EXTERNAL_ZIPIOS=ON
+      - -DFREECAD_USE_PYBIND11=ON
+      - -DFREECAD_USE_QT_FILEDIALOG=OFF
+      - -DBUILD_FLAT_MESH=ON
+    build-packages:
+      - g++
+      - git
+      - libboost-all-dev
+      - libsimage-dev # optional
+      - libspnav-dev # optional
+      - libeigen3-dev
+      - libgts-bin
+      - libgts-dev
+      - libkdtree++-dev
+      - libmedc-dev
+      - libopencv-dev
+      - libproj-dev
+      - libx11-dev
+      - libxerces-c-dev
+      - libzipios++-dev
+      - swig
+      - python3-dev
+      - libocct-data-exchange-dev
+      - libocct-draw-dev
+      - libocct-foundation-dev
+      - libocct-modeling-algorithms-dev
+      - libocct-modeling-data-dev
+      - libocct-ocaf-dev
+      - libocct-visualization-dev
+      - occt-draw
+      - libvtk7-dev
+      - libpyside2-dev
+      - libshiboken2-dev
+      - pybind11-dev
+    stage-packages:
+      - libaec0
+      - libboost-filesystem1.71.0
+      - libboost-program-options1.71.0
+      - libboost-python1.71.0
+      - libboost-regex1.71.0
+      - libboost-system1.71.0
+      - libboost-thread1.71.0
+      - libboost-date-time1.71.0 
+      - libhdf5-openmpi-103
+      - libhwloc15
+      - libilmbase24
+      - libjxr0
+      - libmedc11
+      - libmed11
+      - libopenexr24
+      - libopenmpi3
+      - libpython3.8
+      - libpython3.8-minimal
+      - libpython3.8-stdlib
+      - libraw19
+      - libspnav0
+      - libsz2
+      - libxerces-c3.2
+      - libzipios++0v5
+      - python3-tk # FEM
+      - python3-yaml # FEM
+      - python3-numpy
+      - python3-matplotlib
+      - python3-six
+      - python3-pyparsing
+      - python3-setuptools-scm
+      - python3-cycler
+      - python3-dateutil
+      - python3-git
+      - python3-ply # OpenSCAD
+      - python3-markdown # Addon manager
+      - python3-pyside2.qtcore
+      - python3-pyside2.qtgui
+      - python3-pyside2.qtsvg
+      - python3-pyside2.qtwidgets
+      - python3-pyside2.qtnetwork
+      - graphviz
+      - calculix-ccx # FEM
+      - libfreeimage3
+      - libocct-data-exchange-7.5
+      - libocct-foundation-7.5
+      - libocct-modeling-algorithms-7.5
+      - libocct-modeling-data-7.5
+      - libocct-ocaf-7.5
+      - libocct-visualization-7.5
+      - libtbb2
+      - libvtk7.1p
+      - elmerfem-csc # FEM
+      - openscad  # OpenSCAD
+    override-build: |
+      kde_sdk_dir="/snap/kde-frameworks-5-qt-5-15-3-core20-sdk/current"
+      mkdir -p /etc/xdg/qtchooser
+      cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
+      snapcraftctl build
+      cd $SNAPCRAFT_PART_SRC
+      iso_date=$(date -I)
+      git_hash=$(git rev-parse --short=8 HEAD)
+      version="$iso_date-g$git_hash"
+      snapcraftctl set-version "$version"
+
+  branding:
+    after: [freecad]
+    plugin: nil
+    source: https://github.com/realthunder/FreeCADMakeImage.git
+    override-prime: |
+      export FMK_BUILD_DATE=$(date +%Y%m%d)
+      branding_path=$SNAPCRAFT_PART_SRC/conda/branding/asm3-daily
+      $branding_path/install.sh $branding_path $SNAPCRAFT_PRIME/usr
+      sed -i -E \
+        "s|^Icon=(.*)|Icon=\${SNAP}/usr/share/icons/hicolor/scalable/apps/freecad_link.svg|g" \
+        $SNAPCRAFT_PRIME/freecad_link.desktop
+      
+  assembly3:
+    plugin: dump
+    source: https://github.com/realthunder/FreeCAD_assembly3.git
+    organize:
+      "*": usr/Mod/Assembly3/
+
+  gmsh: # FEM
+    plugin: cmake
+    source: https://gitlab.onelab.info/gmsh/gmsh.git
+    source-tag: gmsh_4_9_3
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DENABLE_BUILD_DYNAMIC=1
+      - -DENABLE_MED=0
+      - -DENABLE_FLTK=0
+
+  pip:
+    plugin: python
+    python-packages:
+      - pip
+    stage-packages:
+      - python3-distutils
+    stage:
+      - -pyvenv.cfg
+
+  cleanup:
+    after: [stub-chown, freecad, pip, gmsh, assembly3, snap-setup-mod, coin3d, pivy, branding]
+    plugin: nil
+    build-snaps: [kde-frameworks-5-qt-5-15-3-core20]
+    override-prime: |
+      set -eux
+      for snap in "kde-frameworks-5-qt-5-15-3-core20"; do  # List all content-snaps you're using here
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" "$SNAPCRAFT_PRIME/usr/{}" \;
+      done
+      for cruft in bug lintian man; do
+        rm -rf $SNAPCRAFT_PRIME/usr/share/$cruft
+      done
+      find $SNAPCRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete
+      find $SNAPCRAFT_PRIME/usr/share -type d -empty -delete


### PR DESCRIPTION
Continuing from https://github.com/ppd/freecad-ppd/issues/5

Obviously, this is not ready to merge yet. I'll clean it up after review.

Just a quick sneak peek, we have an install prompt on first launch that guides the user to install py_slvs:
![Screenshot from 2022-01-03 22-50-19](https://user-images.githubusercontent.com/6652223/147984724-444dc3f1-e338-4d8e-9121-7b0f672e23cd.png)

Maybe we could even integrate this into assembly3 itself.

A fundamental first question would be: How do you want to drive the release process? There are multiple options:
1. Integrate packaging into FreeCAD repo (like this PR)
2. Create new snap releases when assembly3 changes/has a new release. Then this packaging should rather live in the assembly3 repo
3. Have a separate repo just for the packaging. Not so nice because you can't hook into  release events of assembly3 or FreeCAD easily, so manual releasing is necessary.

