### PR TITLE
Spreadsheet: Qt::TextColorRole is obsolete. Use ForegroundRole instead.

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -536,7 +536,7 @@ QVariant SheetModel::headerData(int section, Qt::Orientation orientation, int ro
         else {
             return QString::number(section + 1);
         }
-    } else if (role == Qt::TextColorRole) {
+    } else if (role == Qt::ForegroundRole) {
         if((orientation == Qt::Horizontal && sheet->hiddenColumns.getValues().count(section)) ||
            (orientation == Qt::Vertical && sheet->hiddenRows.getValues().count(section)))
            return QColor(0,0,255);


### PR DESCRIPTION
ref: https://github.com/FreeCAD/FreeCAD/pull/5453
