### PR TITLE
snap: Add layouts for pmix

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,10 @@ layout:
     bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/openmpi
   /usr/bin/orted:
     symlink: $SNAP/usr/bin/orted
+  /usr/share/pmix:
+    symlink: $SNAP/usr/share/pmix
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pmix:
+    symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pmix
   /etc/matplotlibrc:
     bind-file: $SNAP/etc/matplotlibrc
   /usr/share/matplotlib:


### PR DESCRIPTION
OpenMPI can't run if it can't find the pmix libraries etc.
Add symlink layouts to make it work with the upstream packages.
This fixes running ElmerSolver et al. from the FEM workbench.

Fixes realthunder/FreeCAD#275