### PR TITLE
Fixing the boolean on Ellipsoid Primitive

### DIFF
--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -39,6 +39,7 @@
 # include <BRepBuilderAPI_MakeSolid.hxx>
 # include <BRepBuilderAPI_MakePolygon.hxx>
 # include <BRepBuilderAPI_GTransform.hxx>
+# include <ShapeUpgrade_ShapeDivideClosed.hxx>
 # include <BRepProj_Projection.hxx>
 # include <gp_Circ.hxx>
 # include <gp_Elips.hxx>
@@ -461,6 +462,8 @@ App::DocumentObjectExecReturn *Ellipsoid::execute(void)
                                         Angle1.getValue()/180.0f*M_PI,
                                         Angle2.getValue()/180.0f*M_PI,
                                         Angle3.getValue()/180.0f*M_PI);
+        ShapeUpgrade_ShapeDivideClosed SDC(mkSphere.Shape());
+        SDC.Perform();
         Standard_Real scaleX = 1.0;
         Standard_Real scaleZ = Radius1.getValue()/Radius2.getValue();
         // issue #1798: A third radius has been introduced. To be backward
@@ -479,7 +482,7 @@ App::DocumentObjectExecReturn *Ellipsoid::execute(void)
         mat.SetValue(1,3,0.0);
         mat.SetValue(2,3,0.0);
         mat.SetValue(3,3,scaleZ);
-        BRepBuilderAPI_GTransform mkTrsf(mkSphere.Shape(), mat);
+        BRepBuilderAPI_GTransform mkTrsf(SDC.Result(), mat);
         TopoDS_Shape ResultShape = mkTrsf.Shape();
         this->Shape.setValue(ResultShape,false);
     }

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -33,6 +33,7 @@
 # include <BRepPrimAPI_MakeCone.hxx>
 # include <BRepPrimAPI_MakeTorus.hxx>
 # include <BRepPrimAPI_MakePrism.hxx>
+# include <ShapeUpgrade_ShapeDivideClosed.hxx>
 # include <BRepPrim_Cylinder.hxx>
 # include <BRepBuilderAPI_MakePolygon.hxx>
 # include <BRepBuilderAPI_MakeFace.hxx>
@@ -437,6 +438,8 @@ App::DocumentObjectExecReturn* Ellipsoid::execute(void)
                                         Base::toRadians<double>(Angle1.getValue()),
                                         Base::toRadians<double>(Angle2.getValue()),
                                         Base::toRadians<double>(Angle3.getValue()));
+        ShapeUpgrade_ShapeDivideClosed SDC(mkSphere.Shape());
+        SDC.Perform();
         Standard_Real scaleX = 1.0;
         Standard_Real scaleZ = Radius1.getValue()/Radius2.getValue();
         // issue #1798: A third radius has been introduced. To be backward
@@ -455,7 +458,8 @@ App::DocumentObjectExecReturn* Ellipsoid::execute(void)
         mat.SetValue(1,3,0.0);
         mat.SetValue(2,3,0.0);
         mat.SetValue(3,3,scaleZ);
-        BRepBuilderAPI_GTransform mkTrsf(mkSphere.Shape(), mat);
+        BRepBuilderAPI_GTransform mkTrsf(SDC.Result(), mat);
+
         return FeaturePrimitive::execute(mkTrsf.Shape());
     }
     catch (Standard_Failure& e) {


### PR DESCRIPTION
This small changes fix the problem I had with boolean applied to Ellipsoid Primitive.
You may verify that this is true using the file "ballTriplet_bad.FCStd" in the folder named issue2.zip uploaded in the issue 278. The ellipsoidal part is missing in the exported boolean computed without this fix.
It is instead exported well if the structure is recomputed with this fix. 

---
