### PR TITLE
Fix issue with NETGEN dumping output file to main drive root (Windows)

### DIFF
--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
+++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
@@ -4162,8 +4162,15 @@ void NETGENPlugin_NetgenLibWrapper::setMesh( Ng_Mesh* mesh )
 
 std::string NETGENPlugin_NetgenLibWrapper::getOutputFileName()
 {
-//  std::string aTmpDir = SALOMEDS_Tool::GetTmpDir();
+    // "/tmp" doesn't exist on Windows, so it dumps the file to C:\ root
+#ifdef _WIN32
+    char buf[512];
+    memset(buf, 0, sizeof(buf));
+    GetTempPathA(sizeof(buf), buf);
+    const std::string aTmpDir = std::string(buf) + "\\";
+#else
   std::string aTmpDir = "/tmp";
+#endif
 
   TCollection_AsciiString aGenericName = (char*)aTmpDir.c_str();
   aGenericName += "NETGEN_";


### PR DESCRIPTION
On windows, the NETGEN plugin will create a "tmpNETGEN_..._..._.out" file on the main drive root, and not delete it. The plugin is attempting to create a temporary file in "/tmp", which does not exist on Windows.

This change will instead retrieve the appropriate temporary data folder reported by the Windows API.
