### PR TITLE
Fix issue with About screen not displaying underlying splash image if animated gif is on top

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -247,6 +247,7 @@ QLabel *loadSplashGif(QWidget *parent, const char *key, const char *alignmentKey
         gifLabel->setAlignment(Qt::AlignmentFlag(align));
     else
         gifLabel->setAlignment(Qt::AlignTop | Qt::AlignRight);
+    gifLabel->setAttribute(Qt::WA_TranslucentBackground, true);
     return gifLabel;
 }
 } // anonymous namespace


### PR DESCRIPTION
If an animated gif is loaded on top of the standard splash background/image, in the About window, the animated gif blocks visibility of the underlying splash image. Even if the animated gif itself is fully transparent.

Forcing the `Qt::WA_TranslucentBackground` attribute on the `gifLabel` object corrects this issue. 