### PR TITLE
macos: swap `/usr/local` for `${HOMEBREW_PREFIX}`

### DIFF
--- a/src/MacAppBundle/CMakeLists.txt
+++ b/src/MacAppBundle/CMakeLists.txt
@@ -115,6 +115,10 @@ file(GLOB CONFIG_ICU "${HOMEBREW_PREFIX}/Cellar/icu4c*/*/lib")
 
 file(GLOB CONFIG_NGLIB "${HOMEBREW_PREFIX}/Cellar/nglib*/*/Contents/MacOS")
 
+file(GLOB CONFIG_MEDFILE "${HOMEBREW_PREFIX}/opt/med-file*/lib")
+
+file(GLOB CONFIG_GCC "${HOMEBREW_PREFIX}/opt/gcc/lib/gcc/12")
+
 install(CODE 
     "message(STATUS \"Making bundle relocatable...\")
     # The top-level CMakeLists.txt should prevent multiple package manager
@@ -122,6 +126,6 @@ install(CODE
     execute_process(
         COMMAND python2.7
         ${CMAKE_SOURCE_DIR}/src/Tools/MakeMacBundleRelocatable.py
-        ${APP_PATH} ${HOMEBREW_PREFIX}${MACPORTS_PREFIX}/lib ${CONFIG_ICU} /usr/local/opt ${CONFIG_NGLIB} ${Qt5Core_DIR}/../../.. ${XCTEST_PATH} ${HOMEBREW_PREFIX}/opt/llvm/lib ${WEBKIT_FRAMEWORK_DIR}
+        ${APP_PATH} ${HOMEBREW_PREFIX}${MACPORTS_PREFIX}/lib ${CONFIG_GCC} ${CONFIG_ICU} ${CONFIG_MEDFILE} ${HOMBREW_PREFIX}/opt ${Qt5Core_DIR}/../../.. ${XCTEST_PATH} ${HOMEBREW_PREFIX}/opt/llvm/lib ${WEBKIT_FRAMEWORK_DIR}
     )"
 )

--- a/src/MacAppBundle/CMakeLists.txt
+++ b/src/MacAppBundle/CMakeLists.txt
@@ -111,9 +111,9 @@ install(CODE "execute_process(COMMAND chmod -R a+w ${CMAKE_INSTALL_LIBDIR})")
 
 get_filename_component(APP_PATH ${CMAKE_INSTALL_PREFIX} PATH)
 
-file(GLOB CONFIG_ICU "/usr/local/Cellar/icu4c*/*/lib")
+file(GLOB CONFIG_ICU "${HOMEBREW_PREFIX}/Cellar/icu4c*/*/lib")
 
-file(GLOB CONFIG_NGLIB "/usr/local/Cellar/nglib*/*/Contents/MacOS")
+file(GLOB CONFIG_NGLIB "${HOMEBREW_PREFIX}/Cellar/nglib*/*/Contents/MacOS")
 
 install(CODE 
     "message(STATUS \"Making bundle relocatable...\")


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [ ]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [ ]  In case your pull request does more than just fixing small bugs, make sure you discussed your ideas with other developers on the FreeCAD forum
- [ ]  Your branch is [rebased](https://git-scm.com/docs/git-rebase) on latest master `git pull --rebase upstream master`
- [ ]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [ ]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [ ]  Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [FreeCAD bug tracker issue number](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) in case a particular commit solves or is related to an existing issue on the tracker. Ex: `Draft: fix typos - fixes #0004805`

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---


consider swapping (changing) the `/usr/local` for the mac bundling to `${HOMEBREW_PREFIX}` to be a tad more robust for `$USER` installations of homebrew