### PR TITLE
Fix restoring the main window state

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1754,7 +1754,7 @@ void MainWindow::loadWindowSettings()
     config.endGroup();
 
     std::string geometry = d->hGrp->GetASCII("Geometry");
-    std::istringstream iss;
+    std::istringstream iss(geometry);
     int x,y,w,h;
     if (iss >> x >> y >> w >> h) {
         pos = QPoint(x,y);


### PR DESCRIPTION
The state of the main window is saved on exit but not restored when starting. This is important for multi-monitor setups where freecad would not start on the same monitor it was closed on.