### PR TITLE
Gui: Improve object random color

### DIFF
--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -87,21 +87,24 @@ static void inline setRandomColor(const char *name, bool force)
         App::AutoTransaction guard(name, false, true); 
         // get the complete selection
         for (const auto &sel : Selection().getCompleteSelection()) {
-            float fMax = (float)RAND_MAX;
-            float fRed = (float)rand()/fMax;
-            float fGrn = (float)rand()/fMax;
-            float fBlu = (float)rand()/fMax;
+            // compute a random color in the HSV space
+            SbColor color;
+            color.setHSVValue(((float)rand()/RAND_MAX), // [0-1]
+                              ((float)rand()/RAND_MAX) * 0.3 + 0.2, // [0.2-0.5]
+                              ((float)rand()/RAND_MAX) * 0.35 + 0.55); // [0.55-0.9]
 
             ViewProvider* view = Application::Instance->getViewProvider(sel.pObject);
             if (auto vpLink = Base::freecad_dynamic_cast<ViewProviderLink>(view)) {
                 if(!vpLink->OverrideMaterial.getValue())
                     cmdGuiObjectArgs(sel.pObject, "OverrideMaterial = True");
-                cmdGuiObjectArgs(sel.pObject, "ShapeMaterial.DiffuseColor=(%.2f,%.2f,%.2f)", fRed, fGrn, fBlu);
+                cmdGuiObjectArgs(sel.pObject, "ShapeMaterial.DiffuseColor=(%.2f,%.2f,%.2f)",
+                                 color[0], color[1], color[2]);
                 continue;
             }
             if (Base::freecad_dynamic_cast<App::PropertyColor>(view->getPropertyByName("ShapeColor"))) {
                 // get the view provider of the selected object and set the shape color
-                cmdGuiObjectArgs(sel.pObject, "ShapeColor=(%.2f,%.2f,%.2f)", fRed, fGrn, fBlu);
+                cmdGuiObjectArgs(sel.pObject, "ShapeColor=(%.2f,%.2f,%.2f)",
+                                 color[0], color[1], color[2]);
             }
             if (force && Base::freecad_dynamic_cast<App::PropertyBool>(view->getPropertyByName("MapFaceColor"))) {
                 cmdGuiObjectArgs(sel.pObject, "MapFaceColor = False");


### PR DESCRIPTION
Sample in a bounded HSV color space to improve color contrast against object selection, section and sketcher planes.

I'm a heavy user of "object random color" when working. The current object color randomization can be pretty awful, selecting ultra-bright colors that conflict with the sketcher workplane, or impossible to distinguish dark hues.

This changes the random color to select mostly dull but still distinguishable colors that always have good contrast in all view modes (uniform, flat or shadow) and most non-solid/UI elements (sketches, pre/selections, and so on). This is similar in what several commercial CADs already do, although I noticed at least some cycle through a fixed unsaturated palette (onshape, \*cough\*).

Before:
<img src="https://user-images.githubusercontent.com/1017726/212943069-2f7d55e4-04cc-4b0d-bd7b-5d69f3c0c3ac.png" width=250>

After:
<img src="https://user-images.githubusercontent.com/1017726/212943141-72fd38c2-2c50-4649-a4e8-e1512cefd499.png" width=250>

Loading some random model with several parts, this is how the current random object colors tend to fare while trying to pick the _worst_ result in both with flat shading:

<img src="https://user-images.githubusercontent.com/1017726/212942576-8e2c8b8c-9f56-46eb-a23f-0d38cd998539.png" width=800>
<img src="https://user-images.githubusercontent.com/1017726/212943849-9312848c-fc95-4281-9890-5b9eb913dc2a.png" width=800>

With the PR:

<img src="https://user-images.githubusercontent.com/1017726/212942565-3d2d80f6-d4db-4e85-a478-31d73648ceda.png" width=800>
<img src="https://user-images.githubusercontent.com/1017726/212945511-9212616e-b17c-4697-8eaf-9c286d3db03c.png" width=800>
<img src="https://user-images.githubusercontent.com/1017726/212950612-88af3bac-908d-4774-b1b4-515605b9ed35.png" width=800>

This is still implemented as a single-shot randomization without neighboring analysis (that is, we don't try to maximize contrast with close neighbors). Doing that would drastically improve the contrast against parts without having to change the colormap, although if you have "object random color" bound to a hotkey this is already *not bad* and orders of magnitudes better than the current status.