### PR TITLE
Part: Add ParallelPlane attachment mode

### DIFF
--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -110,6 +110,8 @@ enum eMapMode {
     mmOYZ,
     mmOYX,
 
+    mmParallelPlane,
+
     mmDummy_NumberOfModes//a value useful to check the validity of mode value
 };//see also eMapModeStrings[] definition in .cpp
 

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -63,6 +63,9 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
         case mmObjectYZ:
             return TwoStrings(qApp->translate("Attacher3D", "Object's Y Z X","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "X', Y', Z' axes are matched with object's local Y, Z, X, respectively.","Attachment3D mode tooltip"));
+        case mmParallelPlane:
+            return TwoStrings(qApp->translate("Attacher3D", "XY parallel to plane","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "X' Y' plane is parallel to the plane (object's XY) and passes through the vertex.","Attachment3D mode tooltip"));
         case mmFlatFace:
             return TwoStrings(qApp->translate("Attacher3D", "XY on plane","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "X' Y' plane is aligned to coincide planar face.","Attachment3D mode tooltip"));
@@ -138,6 +141,9 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
         case mmObjectYZ:
             return TwoStrings(qApp->translate("Attacher2D", "Object's YZ","AttachmentPlane mode caption"),
                               qApp->translate("Attacher2D", "Plane is aligned to YZ local plane of linked object.","AttachmentPlane mode tooltip"));
+        case mmParallelPlane:
+            return TwoStrings(qApp->translate("Attacher2D", "XY parallel to plane","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "X' Y' plane is parallel to the plane (object's XY) and passes through the vertex","AttachmentPlane mode tooltip"));
         case mmFlatFace:
             return TwoStrings(qApp->translate("Attacher2D", "Plane face","AttachmentPlane mode caption"),
                               qApp->translate("Attacher2D", "Plane is aligned to coincide planar face.","AttachmentPlane mode tooltip"));


### PR DESCRIPTION
Add ParallelPlane attachment/map mode

It results in an attachment similar to ObjectXY but with the XY plane translated to pass through a selected vertex.

It is most useful to place sketches: pick a plane (XY, XZ, YZ) or another sketch then select a vertex to automatically translate the sketch in its Z/normal-direction. In contrast to the Translate attachment/map mode it does not move the origin in 2D/Sketcher.

Here's a screenshot:
![parallel-plane-link](https://github.com/realthunder/FreeCAD/assets/299015/4a890edd-adbb-4303-9515-209d5a7961f0)


This is basically the same change that I proposed and was just merged into FreeCAD main: https://github.com/FreeCAD/FreeCAD/pull/14372
