### PR TITLE
Fix invalid/unnecessary string escape sequences

### DIFF
--- a/src/Ext/freecad/fc_cadquery/selectors.py
+++ b/src/Ext/freecad/fc_cadquery/selectors.py
@@ -182,7 +182,7 @@ class ParallelDirSelector(BaseDirSelector):
             Linear Edges
             Planar Faces
 
-        Use the string syntax shortcut \|(X|Y|Z) if you want to select
+        Use the string syntax shortcut |(X|Y|Z) if you want to select
         based on a cardinal direction.
 
         Example::
@@ -555,7 +555,7 @@ class _SimpleStringSyntaxSelector(Selector):
     def filter(self,objectList):
         """
             selects minimum, maximum, positive or negative values relative to a direction
-            [+\|-\|<\|>\|] \<X\|Y\|Z>
+            [+|-|<|>|] <X|Y|Z>
         """
         return self.mySelector.filter(objectList)
 
@@ -618,7 +618,7 @@ class StringSyntaxSelector(Selector):
 
     ***Modifiers*** are ``('|','+','-','<','>','%')``
 
-        :\|:
+        :|:
             parallel to ( same as :py:class:`ParallelDirSelector` ). Can return multiple objects.
         :#:
             perpendicular to (same as :py:class:`PerpendicularDirSelector` )

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -148,7 +148,7 @@ def saveIcon(key,data,ext):
     iconbank[key] = name
     return name
 
-_Re_Pattern = "<Property name=\"{}\".*?String value=\"(.*?)\"\/>"
+_Re_Pattern = "<Property name=\"{}\".*?String value=\"(.*?)\"/>"
 _Re_CreatedBy = re.compile(_Re_Pattern.format("CreatedBy"))
 _Re_Company = re.compile(_Re_Pattern.format("Company"))
 _Re_License = re.compile(_Re_Pattern.format("License"))


### PR DESCRIPTION
This fixes a couple of occurences of invalid/unnecessary escape sequences in strings. In Python 3.12 these result in `SyntaxWarning`s. The one in `StartPage` is what we're most interested in, as it appears quite prominently when opening FreeCAD:

![image](https://github.com/realthunder/FreeCAD/assets/31203804/a9e9ee96-ecca-4e91-b501-c2ad96a913c4)

Error log:
```
$ FreeCAD                                                                                        1 ↵
FreeCAD 0.21.0, Libs: 0.21.0R38998 (Git)
© Juergen Riegel, Werner Mayer, Yorik van Havre and others 2001-2023
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.
FreeCAD wouldn't be possible without FreeCAD community.
  #####                 ####  ###   ####  
  #                    #      # #   #   # 
  #     ##  #### ####  #     #   #  #   # 
  ####  # # #  # #  #  #     #####  #   # 
  #     #   #### ####  #    #     # #   # 
  #     #   #    #     #    #     # #   #  ##  ##  ##
  #     #   #### ####   ### #     # ####   ##  ##  ##

/usr/lib/freecad/Ext/freecad/fc_cadquery/selectors.py:178: SyntaxWarning: invalid escape sequence '\|'
  """
/usr/lib/freecad/Ext/freecad/fc_cadquery/selectors.py:556: SyntaxWarning: invalid escape sequence '\|'
  """
/usr/lib/freecad/Ext/freecad/fc_cadquery/selectors.py:608: SyntaxWarning: invalid escape sequence '\|'
  """
/usr/lib/freecad/Mod/Start/StartPage/StartPage.py:151: SyntaxWarning: invalid escape sequence '\/'
  _Re_Pattern = "<Property name=\"{}\".*?String value=\"(.*?)\"\/>"
```
