### PR TITLE
[PartDesign] Hole: restore missing call to FeatureAddSub::refineShapeIfActive()

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1970,6 +1970,7 @@ App::DocumentObjectExecReturn* Hole::execute()
             }
             result = base;
         }
+        result = refineShapeIfActive(result);
 
         this->Shape.setValue(result);
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

related to https://github.com/FreeCAD/FreeCAD/issues/17124 (see https://github.com/FreeCAD/FreeCAD/issues/17124#issuecomment-2495432889)

It looks that `PartDesign::Hole::execute()` misses the call to `FeatureAddSub::refineShapeIfActive()` and therefor never refine the shape even if its option is set to `True`.

This PR simply adds that call to generate the shape according to the value of the `Refine` option