### PR TITLE
Fix Tooltip Text Background contrast in Behave-dark.qss

### DIFF
--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -328,8 +328,8 @@ Tooltip
 Gui--TipLabel,
 Gui--NotificationLabel,
 QToolTip {
-    color: #1e1e1e;
-    background-color: #80b4b4b4;
+    color: #65A2E5;
+    background-color: #232932;
 }
 
 


### PR DESCRIPTION
Fixes the tooltip text background contrast in Behave-dark.qss for improved readability.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
